### PR TITLE
Set no need for TFA when devving.

### DIFF
--- a/src/sdg/conf/local_example.py
+++ b/src/sdg/conf/local_example.py
@@ -3,8 +3,8 @@
 #
 import os
 
-os.environ.setdefault("TWO_FACTOR_PATCH_ADMIN", "no"),
-os.environ.setdefault("TWO_FACTOR_FORCE_OTP_ADMIN", "no"),
+os.environ.setdefault("TWO_FACTOR_PATCH_ADMIN", "no")
+os.environ.setdefault("TWO_FACTOR_FORCE_OTP_ADMIN", "no")
 
 
 DATABASES = {
@@ -13,7 +13,7 @@ DATABASES = {
         "NAME": "sdg",
         "USER": "sdg",
         "PASSWORD": "sdg",
-        "HOST": "",  # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
-        "PORT": "",  # Set to empty string for default.
+        "HOST": "localhost",  # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
+        "PORT": 5432,  # Set to empty string for default.
     }
 }


### PR DESCRIPTION
If you copy `local_example.py` to `local.py` you don't need two factor to login.