### PR TITLE
[US-11] Display icon depending on product availability

### DIFF
--- a/src/sdg/scss/components/_general.scss
+++ b/src/sdg/scss/components/_general.scss
@@ -1,4 +1,7 @@
 $color_primary: #396a88;
+
+$color_accent: #ffbc2c;
+
 $color_lightgrey: #e0e0e0;
 $color_darkgrey: #b5b6bb;
 
@@ -7,7 +10,15 @@ $color_darkgrey: #b5b6bb;
 }
 
 .primary {
-  color: $color_primary;
+  color: $color_primary !important;
+}
+
+.accent {
+  color: $color_accent !important;
+}
+
+.dark {
+  color: $color_darkgrey !important;
 }
 
 .divider {

--- a/src/sdg/scss/components/_products.scss
+++ b/src/sdg/scss/components/_products.scss
@@ -67,7 +67,7 @@
     padding: 16px;
     border-radius: 15px;
     display: grid;
-    grid-template-columns: 1fr 14px;
+    grid-template-columns: 14px 1fr 14px;
     grid-gap: 16px;
     align-items: center;
     cursor: pointer;

--- a/src/sdg/templates/core/index.html
+++ b/src/sdg/templates/core/index.html
@@ -8,13 +8,13 @@
 {% block container_title %}Home{% endblock container_title %}
 
 {% block inner %}
-{#    TODO modifiy/update (sample template)#}
     <div class="products">
         <h2 class="products__title">Lokale Overheden</h2>
-        {% for lokaleoverheid in lokale_overheden %}
-            <div class="cards">
-                <a class="cards__card" href="{% url 'organisaties:overheid_detail' pk=lokaleoverheid.pk %}">{{ lokaleoverheid }}</a>
-            </div>
-        {% endfor %}
+        <div class="cards">
+            {% for lokaleoverheid in lokale_overheden %}
+                <a class="cards__card"
+                   href="{% url 'organisaties:overheid_detail' pk=lokaleoverheid.pk %}">{{ lokaleoverheid }}</a>
+            {% endfor %}
+        </div>
     </div>
 {% endblock inner %}

--- a/src/sdg/templates/organisaties/overheid_detail.html
+++ b/src/sdg/templates/organisaties/overheid_detail.html
@@ -84,6 +84,9 @@
                         <div class="products__list-container">
                         {% for product in producten %}
                             <a class="products__item" href="{% url 'producten:detail' pk=product.pk %}">
+                                <div class="products__item-icon">
+                                    <i class="fas fa-dot-circle {% if product.beschikbaar %}primary{% else %}darkgrey{% endif %}"></i>
+                                </div>
                                 <div>
                                     <div class="products__item-title">{{ product.upn_label }}</div>
                                     <div class="products__item-help">{{ product.beschikbare_talen|join:", " }}</div>


### PR DESCRIPTION
Fixes #12

_______

**Changes**

- Display icons for products according to a product's "beschikbaar" property.

![image](https://user-images.githubusercontent.com/58147939/134373201-416f8631-a7df-4e0e-839c-f9e1e82ef435.png)
