### PR TITLE
Styling adjustments for revisions

### DIFF
--- a/src/sdg/scss/components/_colors.scss
+++ b/src/sdg/scss/components/_colors.scss
@@ -37,7 +37,7 @@ $color-bg: #f5f5f5;
 }
 
 .dark {
-  color: $color_grey_dark !important;
+  color: $color_grey_darker !important;
 }
 
 .red {

--- a/src/sdg/scss/components/_revision-list.scss
+++ b/src/sdg/scss/components/_revision-list.scss
@@ -20,5 +20,9 @@
       margin-right: 8px;
       float: left;
     }
+
+    .revision-list__item-text {
+      padding-top: 10px;
+    }
   }
 }

--- a/src/sdg/templates/producten/product_detail.html
+++ b/src/sdg/templates/producten/product_detail.html
@@ -122,9 +122,11 @@
                                         <li class="revision-list__item">
                                             <i class="fas fa-user"></i>
                                             {% blocktrans with user=product_version.gemaakt_door.get_full_name last_modified=product_version.gewijzigd_op version=product_version.versie|default:_("concept") %}
-                                                Gebruiker <strong>{{ user }}</strong> heeft op
-                                                <strong>{{ last_modified }}</strong> product versie
-                                                <strong>{{ version }}</strong> gewijzigd.
+                                                <div class="revision-list__item-text">
+                                                    <span class="primary">{{ user }}</span> heeft op
+                                                    <span class="primary">{{ last_modified }}</span> versie
+                                                    <span class="primary">{{ version }}</span> gewijzigd.
+                                                </div>
                                             {% endblocktrans %}
 
                                             {% if product_version.publicatie_datum %}


### PR DESCRIPTION
**Changes**

- Simplify user revision text to fit one line
- Avoid using bold font
- Adjust padding to center the user's avatar
