### PR TITLE
Correct validation message for opening times

### DIFF
--- a/src/sdg/organisaties/constants.py
+++ b/src/sdg/organisaties/constants.py
@@ -1,5 +1,5 @@
 from django.utils.translation import ugettext_lazy as _
 
 opening_times_error_messages = {
-    "item_invalid": _("Openingstijd %(nth)s is niet geldig. (b.v. 12:00 - 18:00)"),
+    "item_invalid": _("(%(nth)s) Voer een juiste tijd in bijvoorbeeld 12:00 - 18:00."),
 }


### PR DESCRIPTION
Fixes #163

_______

**Changes**

- Changed validation message to include `voer een juiste tijd in bijvoorbeeld 12:00 - 18:00`.