### PR TITLE
Add formatting tools for markdown tables

### DIFF
--- a/src/sdg/conf/base.py
+++ b/src/sdg/conf/base.py
@@ -81,7 +81,6 @@ CACHES = {
     },
 }
 
-
 #
 # APPLICATIONS enabled for this project
 #
@@ -315,7 +314,6 @@ AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
 ]
 
-
 # Allow logging in with both username+password and email+password
 AUTHENTICATION_BACKENDS = [
     "axes.backends.AxesBackend",
@@ -466,6 +464,17 @@ INVITATION_TEMPLATE = "core/email/invitation.html"
 INVITATION_SUBJECT = "Toegang tot de SDG invoervoorziening"
 
 ACCOUNT_ADAPTER = "sdg.accounts.adapters.AccountAdapter"
+
+# Markdown
+MARKDOWNIFY_WHITELIST_TAGS = [
+    "table",
+    "thead",
+    "tbody",
+    "th",
+    "tr",
+    "td",
+]
+MARKDOWNIFY_MARKDOWN_EXTENSIONS = ["markdown.extensions.extra"]
 
 # Celery
 CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://127.0.0.1:6379/4")

--- a/src/sdg/js/components/ckeditor.js
+++ b/src/sdg/js/components/ckeditor.js
@@ -12,8 +12,6 @@ import ParagraphPlugin from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import MarkdownPlugin from '@ckeditor/ckeditor5-markdown-gfm/src/markdown';
 import Table from '@ckeditor/ckeditor5-table/src/table';
 import TableToolbar from '@ckeditor/ckeditor5-table/src/tabletoolbar';
-import TableProperties from '@ckeditor/ckeditor5-table/src/tableproperties';
-import TableCellProperties from '@ckeditor/ckeditor5-table/src/tablecellproperties';
 
 export default class ClassicEditor extends ClassicEditorBase {
 }
@@ -32,8 +30,6 @@ ClassicEditor.builtinPlugins = [
     ParagraphPlugin,
     Table,
     TableToolbar,
-    TableProperties,
-    TableCellProperties,
 ];
 
 ClassicEditor.defaultConfig = {
@@ -53,10 +49,8 @@ ClassicEditor.defaultConfig = {
         ]
     },
     table: {
-        contentToolbar: [
-            'tableColumn', 'tableRow', 'mergeTableCells',
-            'tableProperties', 'tableCellProperties'
-        ],
+        contentToolbar: ['tableColumn', 'tableRow'],
+        defaultHeadings: {rows: 1},
     },
     language: 'nl',
 };

--- a/src/sdg/js/components/ckeditor.js
+++ b/src/sdg/js/components/ckeditor.js
@@ -11,8 +11,12 @@ import ListPlugin from '@ckeditor/ckeditor5-list/src/list';
 import ParagraphPlugin from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import MarkdownPlugin from '@ckeditor/ckeditor5-markdown-gfm/src/markdown';
 import Table from '@ckeditor/ckeditor5-table/src/table';
+import TableToolbar from '@ckeditor/ckeditor5-table/src/tabletoolbar';
+import TableProperties from '@ckeditor/ckeditor5-table/src/tableproperties';
+import TableCellProperties from '@ckeditor/ckeditor5-table/src/tablecellproperties';
 
-export default class ClassicEditor extends ClassicEditorBase {}
+export default class ClassicEditor extends ClassicEditorBase {
+}
 
 ClassicEditor.builtinPlugins = [
     MarkdownPlugin,
@@ -26,7 +30,10 @@ ClassicEditor.builtinPlugins = [
     LinkPlugin,
     ListPlugin,
     ParagraphPlugin,
-    Table
+    Table,
+    TableToolbar,
+    TableProperties,
+    TableCellProperties,
 ];
 
 ClassicEditor.defaultConfig = {
@@ -44,6 +51,12 @@ ClassicEditor.defaultConfig = {
             'undo',
             'redo',
         ]
+    },
+    table: {
+        contentToolbar: [
+            'tableColumn', 'tableRow', 'mergeTableCells',
+            'tableProperties', 'tableCellProperties'
+        ],
     },
     language: 'nl',
 };

--- a/src/sdg/producten/models/fields.py
+++ b/src/sdg/producten/models/fields.py
@@ -1,0 +1,9 @@
+from markdownx.models import MarkdownxField as _MarkdownxField
+
+from sdg.producten.models.validators import validate_no_html
+
+
+class MarkdownxField(_MarkdownxField):
+    """Override `MarkdownxField` with custom validators."""
+
+    validators = [validate_no_html]

--- a/src/sdg/producten/models/localized.py
+++ b/src/sdg/producten/models/localized.py
@@ -3,11 +3,10 @@ from django.db import models
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
-from markdownx.models import MarkdownxField
-
 from sdg.core.db.fields import DynamicArrayField
 from sdg.core.forms import LabeledURLWidget
 from sdg.core.models.validators import validate_labeled_url
+from sdg.producten.models.fields import MarkdownxField
 from sdg.producten.models.managers import LocalizedManager
 from sdg.producten.models.mixins import ProductFieldMixin, TaalMixin
 

--- a/src/sdg/producten/models/validators.py
+++ b/src/sdg/producten/models/validators.py
@@ -1,10 +1,22 @@
 from django.core.exceptions import ValidationError
+from django.core.validators import RegexValidator, _lazy_re_compile
 from django.utils.translation import ugettext_lazy as _
 
-from sdg.producten.models import Product
+no_html_validator = RegexValidator(
+    _lazy_re_compile(r"<(.*)>.*?|<(.*) \>"),
+    message=_(
+        "Het veld mag geen HTML-tags bevatten. Zorg ervoor dat de tabel een header rij heeft."
+    ),
+    code="invalid",
+    inverse_match=True,
+)
 
 
-def validate_product(product: Product):
+def validate_no_html(value):
+    return no_html_validator(value)
+
+
+def validate_product(product):
     """Validate a product (specific / reference).
     - If `product_aanwezig` is False, the product must declare `product_aanwezig_toelichting`.
     """
@@ -16,7 +28,7 @@ def validate_product(product: Product):
         )
 
 
-def validate_specific_product(product: Product):
+def validate_specific_product(product):
     """Validate a specific product.
     - The product must have a reference product.
     - The product's catalog cannot be a referentie catalogus
@@ -41,7 +53,7 @@ def validate_specific_product(product: Product):
         )
 
 
-def validate_reference_product(product: Product):
+def validate_reference_product(product):
     """Validate a reference product.
     - The product's catalog must be a referentie catalogus.
     - The product must have a generic product.

--- a/src/sdg/scss/components/_tabs.scss
+++ b/src/sdg/scss/components/_tabs.scss
@@ -147,6 +147,12 @@
       br {
         display: none;
       }
+
+      table, th, td {
+        border: 1px solid $color_grey;
+        border-collapse: collapse;
+        padding: 6px;
+      }
     }
 
     &--label {


### PR DESCRIPTION
Fixes #299

This issue happens due to a lack of formatting tools (i.e. a header is needed for the table). Added in this PR.

_______

**Changes**

- Added needed formatting tools for markdown tables