### PR TITLE
Small UX stuff

### DIFF
--- a/src/sdg/accounts/admin.py
+++ b/src/sdg/accounts/admin.py
@@ -15,9 +15,7 @@ User = get_user_model()
 class RoleInline(admin.TabularInline):
     model = Role
     extra = 1
-    autocomplete_fields = (
-        "lokale_overheid",
-    )
+    autocomplete_fields = ("lokale_overheid",)
 
     def get_role_user(self, obj):
         return obj.user.email

--- a/src/sdg/producten/models/product.py
+++ b/src/sdg/producten/models/product.py
@@ -473,8 +473,15 @@ class ProductVersie(models.Model):
         verbose_name_plural = _("product versies")
         ordering = ("-versie",)
 
+    def get_pretty_version(self):
+        concept = "(concept)" if not self.publicatie_datum else ""
+        return f"{self.versie} {concept}".strip()
+
+    def get_pretty_name(self):
+        return f"{self.product} (versie {self.get_pretty_version()})"
+
     def __str__(self):
-        return f"{self.product} - {self.versie}"
+        return self.get_pretty_name()
 
     def clean(self):
         super().clean()

--- a/src/sdg/templates/core/base.html
+++ b/src/sdg/templates/core/base.html
@@ -38,11 +38,11 @@
                 {% elif namespace == "organisaties" %}
                     <span>{% trans "Locaties" %}</span>
                 {% else %}
-                    <span>{{ object|title|default:namespace|title }}</span>
+                    <span>{{ object|capfirst|default:namespace|capfirst }}</span>
                 {% endif %}
             </div>
         </div>
-        <h2 class="products__title primary">{{ object|title|default:namespace|title }}</h2>
+        <h2 class="products__title primary">{{ object|capfirst|default:namespace|capfirst }}</h2>
         <hr class="divider">
         {% block inner_content %}
         {% endblock inner_content %}

--- a/src/sdg/templates/organisaties/_include/product_catalog.html
+++ b/src/sdg/templates/organisaties/_include/product_catalog.html
@@ -30,7 +30,7 @@
                     </div>
                     <div>
                         <div class="products__item-title">
-                            {{ product.name|title }}
+                            {{ product.name|capfirst }}
                         </div>
                         <div class="products__item-help">
                             {% for language in product.beschikbare_talen %}

--- a/src/sdg/templates/producten/detail.html
+++ b/src/sdg/templates/producten/detail.html
@@ -107,7 +107,7 @@
                     <li class="revision-list__item">
                         <div>
                             <i class="fas fa-user"></i>
-                            {% blocktrans with user=product_version.gemaakt_door.get_full_name last_modified=product_version.gewijzigd_op version=product_version.versie|default:_("concept") %}
+                            {% blocktrans with user=product_version.gemaakt_door.get_full_name last_modified=product_version.gewijzigd_op version=product_version.get_pretty_version %}
                                 <strong class="revision-list__item--user">{{ user }}</strong>
                                 </div>
                                 <div>


### PR DESCRIPTION
Really minor UX stuff that I noticed while browsing:

* Changed titles to show only with capfirst instead of every word being capped.
* Changed title to show that the number refers to a version.