### PR TITLE
Role list updates

### DIFF
--- a/src/sdg/organisaties/views/roles.py
+++ b/src/sdg/organisaties/views/roles.py
@@ -20,7 +20,6 @@ class RoleListView(RoleBaseMixin, OverheidMixin, ListView):
         context[
             "lokaleoverheid_beheerder"
         ] = self.lokale_overheid.user_has_manager_role(self.request.user)
-        context["users_without_role"] = User.objects.filter(roles__isnull=True)
         return context
 
 

--- a/src/sdg/templates/organisaties/roles/list.html
+++ b/src/sdg/templates/organisaties/roles/list.html
@@ -34,9 +34,6 @@
                                     {% include "organisaties/roles/_user.html" %}
                                 {% endwith %}
                             {% endfor %}
-                            {% for user in users_without_role %}
-                                {% include "organisaties/roles/_user.html" %}
-                            {% endfor %}
                             </tbody>
                         </table>
                         <div class="roles__control">


### PR DESCRIPTION
Fixes #340

_______

**Changes**

- Do not display users without roles (only if a role exists for the municipality)