### PR TITLE
Add extra warning if product form is invalid

### DIFF
--- a/src/sdg/producten/views/product.py
+++ b/src/sdg/producten/views/product.py
@@ -182,11 +182,11 @@ class ProductUpdateView(OverheidMixin, UpdateView):
             return HttpResponseRedirect(self.get_success_url())
 
     def form_invalid(self, form, version_form, product_form):
-        return self.render_to_response(
-            self.get_context_data(
-                form=form, version_form=version_form, product_form=product_form
-            )
+        context = self.get_context_data(
+            form=form, version_form=version_form, product_form=product_form
         )
+        context["form_invalid"] = True
+        return self.render_to_response(context)
 
     def get_success_url(self):
         return reverse(

--- a/src/sdg/scss/components/_form.scss
+++ b/src/sdg/scss/components/_form.scss
@@ -232,6 +232,10 @@
       background-color: lighten($color_red, 36%);
       padding: 14px;
       list-style: none;
+
+      &::before {
+        content: "" !important;
+      }
     }
   }
 }

--- a/src/sdg/scss/components/_notifications.scss
+++ b/src/sdg/scss/components/_notifications.scss
@@ -43,12 +43,13 @@
     }
 
     &.notification__error {
-      border-left: 5px solid $color_grey_dark;
-      background-color: $color_grey_light;
+      border-left: 5px solid $color_red;
+      background-color: lighten($color_red, 36%);
+      color: $color_red;
 
       .svg-inline--fa,
       a {
-        color: $color_grey_darkest;
+        color: $color_red;
       }
     }
 
@@ -62,6 +63,7 @@
         color: $color_accent_darkest;
       }
     }
+
 
   }
 }

--- a/src/sdg/templates/producten/update.html
+++ b/src/sdg/templates/producten/update.html
@@ -36,6 +36,13 @@
 
 {% block inner_content %}
     <div class="notifications">
+        {% if form_invalid %}
+            <div class="notifications__notification notification__accent">
+                <i class="fas fa-exclamation-triangle"></i>
+                <span>{% trans "Wijzigingen konden niet worden opgeslagen. Corrigeer de hieronder gemarkeerde fouten." %}</span>
+                <span></span>
+            </div>
+        {% endif %}
         {% include "core/_notifications.html" %}
         {% include 'producten/_include/edit_warnings.html' %}
     </div>

--- a/src/sdg/templates/producten/update.html
+++ b/src/sdg/templates/producten/update.html
@@ -37,8 +37,8 @@
 {% block inner_content %}
     <div class="notifications">
         {% if form_invalid %}
-            <div class="notifications__notification notification__accent">
-                <i class="fas fa-exclamation-triangle"></i>
+            <div class="notifications__notification notification__error">
+                <i class="fas fa-times-circle"></i>
                 <span>{% trans "Wijzigingen konden niet worden opgeslagen. Corrigeer de hieronder gemarkeerde fouten." %}</span>
                 <span></span>
             </div>


### PR DESCRIPTION
Fixes #369

_______

**Changes**

- Add fixed warning if the product form is invalid

![warning](https://user-images.githubusercontent.com/58147939/150159170-94d8b874-e7c7-4775-bd1d-9ad702a271c0.png)

Update:

![image](https://user-images.githubusercontent.com/58147939/150546867-c8f19e3f-3125-428b-8050-36ff4fb134a0.png)
