### PR TITLE
Remove certain fields for reference product edit page

### DIFF
--- a/src/sdg/templates/forms/table_field.html
+++ b/src/sdg/templates/forms/table_field.html
@@ -13,9 +13,9 @@
                     {{ field|addclass:"form__input" }}
                 </div>
                 {{ field.errors }}
-                {% if not is_reference %}
                     <div class="toolbar">
                         <div class="button-group">
+                            {% if not is_reference %}
                             <button class="button button--light button--small form__diff-btn" type="button">
                                 <i class="fa fa-eye fa-xs"></i>
                                 Vergelijken
@@ -30,11 +30,10 @@
                                 <i class="fa fa-undo fa-xs"></i>
                                 Gebruik standaardtekst
                             </button>
-
+                            {% endif %}
                         </div>
                         {% toggle _('Aanpassen') hide_label=True icon_before='lock' icon_after='lock-open' %}
                     </div>
-                {% endif %}
             {% endif %}
         </td>
     </tr>

--- a/src/sdg/templates/producten/update.html
+++ b/src/sdg/templates/producten/update.html
@@ -57,65 +57,67 @@
                 <tr>
                 </tr>
 
-                {% with field=product_form.product_aanwezig %}
-                    {% with configuration=field.configuration.0 %}
-                        <tr>
-                            <td class="tabs__table-cell" width="25%">{{ configuration.0|default:field.label|capfirst }}<i
-                                class="fas fa-info-circle fa-xs dark"
-                                title="{{ configuration.1|default:field.help_text }}"></i>
-                            </td>
-                            <td class="tabs__table-cell">
-                                {% select field %}
-                                {{ field.errors }}
-                            </td>
-                        </tr>
+                {% if not product.is_referentie_product %}
+                    {% with field=product_form.product_aanwezig %}
+                        {% with configuration=field.configuration.0 %}
+                            <tr>
+                                <td class="tabs__table-cell" width="25%">{{ configuration.0|default:field.label|capfirst }}<i
+                                    class="fas fa-info-circle fa-xs dark"
+                                    title="{{ configuration.1|default:field.help_text }}"></i>
+                                </td>
+                                <td class="tabs__table-cell">
+                                    {% select field %}
+                                    {{ field.errors }}
+                                </td>
+                            </tr>
+                        {% endwith %}
                     {% endwith %}
-                {% endwith %}
 
-                {% with field=product_form.product_aanwezig_toelichting %}
-                    {% with configuration=field.configuration.0 %}
-                        <tr>
-                            <td class="tabs__table-cell"
-                                width="25%">{{ configuration.0|default:field.label|capfirst }}<i
-                                class="fas fa-info-circle fa-xs dark"
-                                title="{{ configuration.1|default:field.help_text }}"></i></td>
-                            <td class="tabs__table-cell">
-                                {{ field|addclass:"form__input" }}
-                                {{ field.errors }}
-                            </td>
-                        </tr>
+                    {% with field=product_form.product_aanwezig_toelichting %}
+                        {% with configuration=field.configuration.0 %}
+                            <tr>
+                                <td class="tabs__table-cell"
+                                    width="25%">{{ configuration.0|default:field.label|capfirst }}<i
+                                    class="fas fa-info-circle fa-xs dark"
+                                    title="{{ configuration.1|default:field.help_text }}"></i></td>
+                                <td class="tabs__table-cell">
+                                    {{ field|addclass:"form__input" }}
+                                    {{ field.errors }}
+                                </td>
+                            </tr>
+                        {% endwith %}
                     {% endwith %}
-                {% endwith %}
 
-                {% with field=product_form.product_valt_onder %}
-                    {% with configuration=field.configuration.0 %}
-                        <tr>
-                            <td class="tabs__table-cell"
-                                width="25%">{{ configuration.0|default:field.label|capfirst }}<i
-                                class="fas fa-info-circle fa-xs dark"
-                                title="{{ configuration.1|default:field.help_text }}"></i></td>
-                            <td class="tabs__table-cell">
-                                {% select field %}
-                                {{ field.errors }}
-                            </td>
-                        </tr>
+                    {% with field=product_form.product_valt_onder %}
+                        {% with configuration=field.configuration.0 %}
+                            <tr>
+                                <td class="tabs__table-cell"
+                                    width="25%">{{ configuration.0|default:field.label|capfirst }}<i
+                                    class="fas fa-info-circle fa-xs dark"
+                                    title="{{ configuration.1|default:field.help_text }}"></i></td>
+                                <td class="tabs__table-cell">
+                                    {% select field %}
+                                    {{ field.errors }}
+                                </td>
+                            </tr>
+                        {% endwith %}
                     {% endwith %}
-                {% endwith %}
 
-                {% with field=product_form.locaties %}
-                    {% with configuration=field.configuration.0 %}
-                        <tr>
-                            <td class="tabs__table-cell" width="25%">{{ configuration.0|default:field.label|capfirst }} <i
-                                class="fas fa-info-circle fa-xs dark"
-                                title="{{ configuration.1|default:field.help_text }}"></i>
-                            </td>
-                            <td class="tabs__table-cell">
-                                {{ field }}
-                                {{ field.errors }}
-                            </td>
-                        </tr>
+                    {% with field=product_form.locaties %}
+                        {% with configuration=field.configuration.0 %}
+                            <tr>
+                                <td class="tabs__table-cell" width="25%">{{ configuration.0|default:field.label|capfirst }} <i
+                                    class="fas fa-info-circle fa-xs dark"
+                                    title="{{ configuration.1|default:field.help_text }}"></i>
+                                </td>
+                                <td class="tabs__table-cell">
+                                    {{ field }}
+                                    {{ field.errors }}
+                                </td>
+                            </tr>
+                        {% endwith %}
                     {% endwith %}
-                {% endwith %}
+                {% endif %}
 
                 {% with publication_date=product.active_version|get_field:"publicatie_datum" %}
                     {% with configuration=publication_date.configuration.0 %}


### PR DESCRIPTION
Fixes #424

_______

**Changes**

(Reference products only)

- Removed "product_aanwezig", "product_aanwezig_toelichting", "locaties" fields entirely from edit page.