### PR TITLE
:sparkles: #454 - Make the use of standard text use easier

### DIFF
--- a/src/sdg/js/components/abstract/component.js
+++ b/src/sdg/js/components/abstract/component.js
@@ -4,21 +4,59 @@
 /**
  * Base class for implementing simple components.
  * Provides read-only state machine mutable by setState().
- * Updating state results a render being called.
+ * Updating state results in a render being called.
+ *
+ * Please see options for list of available options.
  * @abstract
  */
 export class Component {
     /**
+     * Default state object.
+     * Use this to specify the default state of the component.
+     * @type {Object}
+     */
+    static initialState = {};
+
+    /**
+     * Options object.
+     * Use this to specify the options of the component.
+     *
+     * Options:
+     *  - observe {boolean} Use a MutationObserver to track, and react on changes to this.node in DOM.
+     *
+     * @type {Object}
+     */
+    static options = {};
+
+    /**
      * Constructor method.
      * @param {HTMLElement} node
      * @param {Object} initialState
+     * @param {Object} options
      */
-    constructor(node, initialState = {}) {
+    constructor(
+        node,
+        initialState = this.constructor.initialState,
+        options = this.constructor.options
+    ) {
         /** @type {HTMLElement} */
         this.node = node;
 
+        /** @type {boolean} Whether the `this.node` is considered to be mounted (attached to DOM). */
+        this._isMounted = false;
+
+        /** @type {Object} */
+        this._options = this._getOptions(options);
+
+        /** @type {(MutationObserver|null)} */
+        this._mutationObserver = this._options.observe ? this._getMutationObserver() : null;
+
+
+        /** @type {Object} */
+        this.state = {};
+
         // Protect state methods.
-        ['setState', '_setState'].forEach((methodName) =>
+        ['setState', '_setState', '_bindEvents'].forEach((methodName) =>
             Object.defineProperty(this, methodName, {
                 configurable: false,
                 value: Component.prototype[methodName].bind(this),
@@ -26,11 +64,32 @@ export class Component {
             })
         );
 
-        // Allow other constructor to complete first.
-        setTimeout(() => {
-            this.setState(initialState);
-            this.bindEvents();
-        });
+        // Mark read only.
+        this._markReadOnly(this, '_options', this._options);
+        this._markReadOnly(this, 'state', this.state);
+
+        if (this._options.observe) {
+            this._markReadOnly(this, 'mutationObserver', this._mutationObserver);
+        }
+
+        this._setState(initialState);
+        this._bindEvents();
+    }
+
+    /**
+     * Gets called after the first render cycle.
+     * Use this to sync state with DOM on initial mount.
+     */
+    onMount() {
+    }
+
+    /**
+     * Gets called when MutationObservers detects a mutation.
+     * Only when `options.observe` is set to `true`.
+     * Use this to sync state with DOM updates.
+     * @param {MutationRecord} mutationRecord
+     */
+    onMutation(mutationRecord) {
     }
 
     /**
@@ -39,6 +98,7 @@ export class Component {
      */
     bindEvents() {
     }
+
 
     /**
      * Updates the state with given update.
@@ -60,6 +120,89 @@ export class Component {
     }
 
     /**
+     * (Re)connects the MutationObserver.
+     * requires `options.observe` to be `true`.
+     */
+    connectObserver() {
+        if (!this._options.observe) {
+            throw new Error(`Cannot connect uninitialized MutationObserver on ${this.node}, please use options.observe.`);
+        }
+
+        // Postpone re-observation to the end of the event loop.
+        setTimeout(() => {
+            this._mutationObserver?.observe(this.node, {
+                attributes: true,
+                childList: true,
+                subtree: true,
+                attributeOldValue: true,
+            });
+        });
+    }
+
+    /**
+     * Disconnects the MutationObserver.
+     * requires `options.observe` to be `true`.
+     */
+    disconnectObserver() {
+        if (!this._options.observe) {
+            throw new Error(`Cannot disconnect uninitialized MutationObserver on ${this.node}, please use options.observe.`);
+        }
+        this._mutationObserver?.disconnect();
+    }
+
+    /**
+     * Returns the combined options.
+     * @param {Object} options
+     * @return {Object}
+     * @private
+     */
+    _getOptions(options) {
+        const defaults = {
+            observe: false,
+        }
+        return Object.assign(defaults, options);
+    }
+
+    /**
+     * Binds events to callbacks.
+     */
+    _bindEvents() {
+        if (this._options.observe) {
+            this.connectObserver();
+        }
+
+        // Allow component implementation to construct first.
+        // This allows `this.bindEvens()` to use attributes specified implementation's constructor.
+        setTimeout(this.bindEvents.bind(this));
+    }
+
+    /**
+     * Returns a MutationObserver observing changes to this.node.
+     * Changes to this.node result in render.
+     * @return {MutationObserver}
+     * @private
+     */
+    _getMutationObserver() {
+        if (!this._options.observe) {
+            throw new Error(`Cannot create MutationObserver on ${this.node}, please use options.observe.`);
+        }
+
+        return new MutationObserver(this._onMutation.bind(this));
+    }
+
+    /**
+     * Gets called when MutationObservers detects a mutation.
+     * Only when `options.observe` is set to `true`.
+     * @param {MutationRecord[]} mutationRecords
+     * @param {MutationObserver} mutationObserver
+     */
+    _onMutation(mutationRecords, mutationObserver) {
+        [...mutationRecords].forEach((mutationRecord) => {
+            this.onMutation(mutationRecord);
+        });
+    }
+
+    /**
      * Updates the state, this cannot be extended.
      * @param {Object} update partial state with only updated entries.
      * @return {Object} New state.
@@ -75,33 +218,57 @@ export class Component {
         this._markReadOnly(this, 'state', state);
 
         // Trigger render.
-        this.render(this.state);
+        setTimeout(() => {
+            this._render(this.state);
+        })
         return this.state;
     }
 
     /**
      * Updates key on obj by setting readonly value.
-     * @param {obj} obj
+     * @param {Object} obj
      * @param {*} key
      * @param {*} value
      * @return The readonly obj[key].
      * @private
      */
     _markReadOnly(obj, key, value) {
-        try {
-            obj = Object.defineProperty(obj, key, {
-                configurable: true,
-                value: value,
-                writable: false,
-            });
+        obj = Object.defineProperty(obj, key, {
+            configurable: true,
+            value: value,
+            writable: false,
+        });
+
+        if (typeof value === 'object' && value !== null) {
             Object.entries(value).forEach(([nestedKey, nestedValue]) => {
                 this._markReadOnly(value, nestedKey, nestedValue);
             });
-
-        } catch (e) {
-            console.warn(e);
         }
 
         return obj[key];
+    }
+
+    /**
+     * Renders state.
+     * Gets called when state gets updated.
+     * Disconnects this._mutationObserver temporary while allow this.render() to execute.
+     * This prevents infinite loops while rendering.
+     * @param {Object} state Read only state.
+     */
+    _render(state) {
+        if (this._options.observe) {
+            this.disconnectObserver();
+        }
+
+        this.render(state);
+
+        if (this._options.observe) {
+            this.connectObserver();
+        }
+
+        if (!this._isMounted && this.node.isConnected) {
+            this._isMounted = true;
+            this.onMount();
+        }
     }
 }

--- a/src/sdg/js/components/form/abstract/form_component.js
+++ b/src/sdg/js/components/form/abstract/form_component.js
@@ -2,6 +2,10 @@ import {Component} from '../../abstract/component';
 import {availableEditors} from '../../markdown';
 
 
+/**
+ * Base class for implementing components within the update form.
+ * @abstract
+ */
 export class FormComponent extends Component {
     /**
      * Binds events to callbacks.
@@ -19,20 +23,47 @@ export class FormComponent extends Component {
     }
 
     /**
-     * Returns the reference text template.
-     * @return {HTMLTemplateElement}
-     */
-    getReferenceTemplate() {
-        return document.querySelector(".form__reference--display-template");
-    }
-
-    /**
      * Returns the form control (table cell) containing this button.
      * @param {HTMLElement} [child]
      * @return {HTMLElement}
      */
     getFormControl(child) {
         return this._getParent('form__cell', child);
+    }
+
+    /**
+     * Returns whether the form control is disabled.
+     * @return {boolean}
+     */
+    getFormControlDisabled() {
+        return this.getFormControl().classList.contains('form__cell--disabled');
+    }
+
+    /**
+     * Sets the disabled state of the form control.
+     * @param {boolean} disabled
+     * @param {HTMLElement} [formControl]
+     */
+    setFormControlDisabled(disabled, formControl = this.getFormControl()) {
+        formControl.classList.toggle('form__cell--disabled', disabled);
+        const toggleInput = formControl.querySelector('.toolbar .toggle input ');
+
+        // Update toggle.
+        if(toggleInput) {
+            toggleInput.checked = !disabled;
+        }
+
+        // Update input/select/textarea.
+        [...formControl.querySelectorAll(`
+            .form__cell input,
+            .form__cell select,
+            .form__cell textarea
+        `)].forEach((field) => {
+            field.readOnly = disabled;
+        });
+
+        // Update reference button.
+        formControl.querySelector('.form__cell .form__reference-btn')?.toggleAttribute('disabled', disabled);
     }
 
     /**
@@ -69,59 +100,11 @@ export class FormComponent extends Component {
     }
 
     /**
-     * Returen the reference form.
-     * @return {HTMLTemplateElement}
-     */
-    getCurrentReferenceForm() {
-        const referenceFormSelector = this.getTable().dataset.reference;
-        return document.querySelector(referenceFormSelector);
-    }
-
-    /**
-     * Returen the previous reference form.
-     * @return {HTMLTemplateElement}
-     */
-    getPreviousReferenceForm() {
-        const previousReferenceFormSelector = this.getTable().dataset.previousreference;
-        return document.querySelector(previousReferenceFormSelector);
-    }
-
-    /**
      * Returns the HTMLElement containing the version labels.
      * @return {HTMLElement}
      */
     getVersionsContainer() {
         return this.getFormControl().querySelector('.tabs__table-cell--versions');
-    }
-
-    /**
-     * Returns the current version data.
-     * @return {{input: (HTMLInputElement|HTMLTextAreaElement), title: string}}
-     */
-    getCurrentVersionData() {
-        const inputOrTextarea = this.getInputOrTextarea();
-        const currentReferenceForm = this.getCurrentReferenceForm();
-        const currentReferenceInput = currentReferenceForm.content.querySelector(`#${inputOrTextarea.id}`);
-
-        return {
-            'title': 'Uw tekst',
-            'input': currentReferenceInput,
-        };
-    }
-
-    /**
-     * Returns the previous version data.
-     * @return {{input: (HTMLInputElement|HTMLTextAreaElement), title: string}}
-     */
-    getPreviousVersionData() {
-        const inputOrTextarea = this.getInputOrTextarea();
-        const previousReferenceForm = this.getPreviousReferenceForm();
-        const previousReferenceInput = previousReferenceForm.content.querySelector(`#${inputOrTextarea.id}`);
-
-        return {
-            'title': previousReferenceForm.dataset.title,
-            'input': previousReferenceInput,
-        };
     }
 
     /**
@@ -141,7 +124,7 @@ export class FormComponent extends Component {
         const inputOrTextarea = this.getInputOrTextarea();
         const editor = availableEditors[inputOrTextarea.id];
 
-        if(editor) {
+        if (editor) {
             editor.setValue(value);
             return;
         }
@@ -156,7 +139,7 @@ export class FormComponent extends Component {
      * @return {HTMLElement}
      * @private
      */
-    _getParent(className, child=this.node) {
+    _getParent(className, child = this.node) {
         let iteratedNode = child.parentElement;
         let i = 1;
 

--- a/src/sdg/js/components/form/abstract/reference_text_component.js
+++ b/src/sdg/js/components/form/abstract/reference_text_component.js
@@ -1,0 +1,187 @@
+/**
+ * Base class for implementing components within the update form.
+ * @abstract
+ */
+import showdown from 'showdown';
+import {FormComponent} from './form_component';
+
+export class ReferenceTextComponent extends FormComponent {
+    /**
+     * Options object.
+     * Use this to specify the options of the component.
+     *
+     * @type {Object}
+     */
+    static options = {
+        observe: true,
+    }
+
+    /**
+     * Binds events to callbacks.
+     * Use this to define EventListeners, MutationObservers etc.
+     */
+    bindEvents() {
+        super.bindEvents();
+        this.getReferenceTextToolbar().querySelector('.form__reference-btn').addEventListener('click', () => this.setState({active: false}));
+    }
+
+    /**
+     * Gets called after the first render cycle.
+     * Use this to sync state with DOM on initial mount.
+     */
+    onMount() {
+        super.onMount();
+
+        this.updateDisabled();
+        this.updateLabel();
+    }
+
+    /**
+     * Gets called when MutationObservers detects a mutation.
+     * Only when `options.observe` is set to `true`.
+     * Use this to sync state with DOM updates.
+     * @param {MutationRecord} mutationRecord
+     */
+    onMutation(mutationRecord) {
+        super.onMutation(mutationRecord);
+
+        const disabled = Boolean(mutationRecord.target[mutationRecord.attributeName]);
+        this.setState({disabled: disabled});
+
+        this.updateDisabled();
+        this.updateLabel();
+    }
+
+    /**
+     * Updates the disabled state based on whether reference HTML is available.
+     */
+    updateDisabled() {
+        if (!this.getReferenceHTML()) {
+            this.setState({disabled: true})
+        }
+    }
+
+    /**
+     * Updates the label state based on disabled attribute.
+     */
+    updateLabel() {
+        // Make sure we keep track of the original label.
+        if (!this.state.originalLabel) {
+            this.setState({originalLabel: this.node.textContent});
+        }
+
+        // Show custom label if no reference text is available.
+        if (!this.getReferenceHTML()) {
+            this.setState({label: 'Geen standaardtekst beschikbaar'});
+        } else if (this.state.originalLabel) {
+            this.setState({label: this.state.originalLabel});
+        }
+    }
+
+    /**
+     * Returns the current version data.
+     * @return {{input: (HTMLInputElement|HTMLTextAreaElement), title: string}}
+     */
+    getCurrentVersionData() {
+        const inputOrTextarea = this.getInputOrTextarea();
+        const currentReferenceForm = this.getCurrentReferenceForm();
+        const currentReferenceInput = currentReferenceForm.content.querySelector(`#${inputOrTextarea.id}`);
+
+        return {
+            'title': 'Uw tekst',
+            'input': currentReferenceInput,
+        };
+    }
+
+    /**
+     * Returns the previous version data.
+     * @return {{input: (HTMLInputElement|HTMLTextAreaElement), title: string}}
+     */
+    getPreviousVersionData() {
+        const inputOrTextarea = this.getInputOrTextarea();
+        const previousReferenceForm = this.getPreviousReferenceForm();
+        const previousReferenceInput = previousReferenceForm.content.querySelector(`#${inputOrTextarea.id}`);
+
+        return {
+            'title': previousReferenceForm.dataset.title,
+            'input': previousReferenceInput,
+        };
+    }
+
+    /**
+     * Returen the reference form.
+     * @return {HTMLTemplateElement}
+     */
+    getCurrentReferenceForm() {
+        const referenceFormSelector = this.getTable().dataset.reference;
+        return document.querySelector(referenceFormSelector);
+    }
+
+    /**
+     * Returen the previous reference form.
+     * @return {HTMLTemplateElement}
+     */
+    getPreviousReferenceForm() {
+        const previousReferenceFormSelector = this.getTable().dataset.previousreference;
+        return document.querySelector(previousReferenceFormSelector);
+    }
+
+    /**
+     * Returns the reference container.
+     * @return {HTMLElement}
+     */
+    getReferenceTextContainer() {
+        return this.getFormControl().querySelector('.form__reference');
+    }
+
+    /**
+     * Returns the reference text template.
+     * @return {HTMLTemplateElement}
+     */
+    getReferenceTemplate() {
+        return document.querySelector(".form__reference--display-template");
+    }
+
+    /**
+     * Returns the reference toolbar.
+     * @return {HTMLElement}
+     */
+    getReferenceTextToolbar() {
+        return this.getFormControl().querySelector('.form__reference + .toolbar');
+    }
+
+    /**
+     * Returns the reference HTML.
+     * @return {string}
+     */
+    getReferenceHTML() {
+        const inputOrTextarea = this.getInputOrTextarea();
+        const referenceForm = this.getCurrentReferenceForm();
+        const referenceField = referenceForm.content.getElementById(inputOrTextarea.id);
+        return new showdown.Converter().makeHtml(referenceField.value);
+    }
+
+    /**
+     * Renders state.
+     * Gets called when state gets updated.
+     * Use this to persist (read only) state to DOM.
+     * @param {Object} state Read only state.
+     */
+    render(state) {
+        const {active, disabled, label} = state;
+
+        super.render(state);
+
+        this.node.classList.toggle('button--active', Boolean(active));
+
+        if (disabled === true) {
+            this.node.setAttribute('disabled', true);
+        } else if (disabled === false) {
+            this.node.removeAttribute('disabled');
+        }
+
+        if (label) {
+            this.node.innerHTML = `${this.node.children[0]?.outerHTML} ${label}`;
+        }
+    }
+}

--- a/src/sdg/js/components/form/diff_button.js
+++ b/src/sdg/js/components/form/diff_button.js
@@ -1,15 +1,14 @@
 import Diff from 'text-diff';
-import {FormComponent} from './abstract/form_component';
+import {ReferenceTextComponent} from './abstract/reference_text_component';
 
 
 /** @type {NodeListOf<HTMLAnchorElement>} */
 const DIFF_BUTTONS = document.querySelectorAll('.form__diff-btn');
 
-
 /**
  * Button showing diffs between user and stored value of an input.
  */
-class DiffButton extends FormComponent {
+class DiffButton extends ReferenceTextComponent {
     /**
      * Gets called when this.node gets clicked.
      * @param {MouseEvent} event
@@ -124,9 +123,9 @@ class DiffButton extends FormComponent {
      * @param {Object} state Read only state.
      */
     render(state) {
-        const {active} = state;
+        super.render(state);
 
-        this.node.classList.toggle('button--active', Boolean(active));
+        const {active} = state;
 
         this.renderDiffElement(state);
         this.renderVersionContainer();

--- a/src/sdg/js/components/form/show_reference_button.js
+++ b/src/sdg/js/components/form/show_reference_button.js
@@ -1,5 +1,4 @@
-import showdown from 'showdown';
-import {FormComponent} from './abstract/form_component';
+import {ReferenceTextComponent} from './abstract/reference_text_component';
 
 
 /** @type {NodeListOf<HTMLAnchorElement>} */
@@ -9,19 +8,14 @@ const SHOW_REFERENCE_BUTTONS = document.querySelectorAll('.form__display-btn');
 /**
  * Button allow the user to use the reference text.
  */
-class ShowReferenceButton extends FormComponent {
+class ShowReferenceButton extends ReferenceTextComponent {
     /**
      * Gets called when this.node gets clicked.
      * @param {MouseEvent} event
      */
     onClick(event) {
         event.preventDefault();
-        const inputOrTextarea = this.getInputOrTextarea();
-        const referenceForm = this.getCurrentReferenceForm();
-        const referenceField = referenceForm.content.getElementById(inputOrTextarea.id);
-        const referenceHTML = new showdown.Converter().makeHtml(referenceField.value);
-
-        this.setState({active: !this.state.active, referenceHTML: referenceHTML});
+        this.setState({active: !this.state.active, referenceHTML: this.getReferenceHTML()});
     }
 
     /**
@@ -33,41 +27,19 @@ class ShowReferenceButton extends FormComponent {
     }
 
     /**
-     * Sets the active icon.
-     */
-    setActiveIcon() {
-        const icon = this.getIcon();
-        icon.classList.remove('fa-chevron-right');
-        icon.classList.add('fa-chevron-down');
-    }
-
-    /**
-     * Sets the inactive icon.
-     */
-    setInActiveIcon() {
-        const icon = this.getIcon();
-        icon.classList.remove('fa-chevron-down');
-        icon.classList.add('fa-chevron-right');
-    }
-
-    /**
      * Shows the reference text.
      */
     showReferenceText() {
-        if (!this.referenceTextContainer) {
-            return;
-        }
-        this.referenceTextContainer.style.removeProperty('display');
+        this.getReferenceTextContainer().removeAttribute('aria-hidden');
+        this.getReferenceTextToolbar().removeAttribute('aria-hidden');
     }
 
     /**
      * Hide the refence text.
      */
     hideReferenceText() {
-        if (!this.referenceTextContainer) {
-            return;
-        }
-        this.referenceTextContainer.style.setProperty('display', 'none');
+        this.getReferenceTextContainer().setAttribute('aria-hidden', true);
+        this.getReferenceTextToolbar().setAttribute('aria-hidden', true);
     }
 
     /**
@@ -76,23 +48,18 @@ class ShowReferenceButton extends FormComponent {
      * Use this to persist (read only) state to DOM.
      * @param {Object} state Read only state.
      */
-    render({active, referenceHTML}) {
-        this.node.classList.toggle('button--active', Boolean(active));
+    render(state) {
+        super.render(state);
 
-        if (!this.referenceTextContainer) {
-            const referenceTemplate = this.getReferenceTemplate();
-            this.referenceTextContainer = document.importNode(referenceTemplate.content.children[0], true);
-            this.getFormControl().appendChild(this.referenceTextContainer);
-        }
+        const {active, referenceHTML} = state;
+        const iconRotation = (active) ? 90 : 0;
 
-        const referenceHTMLWrapper = this.referenceTextContainer.querySelector('.reference__display--content');
-        referenceHTMLWrapper.innerHTML = referenceHTML;
+        this.getIcon().style.transform = `rotate(${iconRotation}deg)`;
 
         if (active) {
-            this.setActiveIcon();
+            this.getReferenceTextContainer().innerHTML = referenceHTML;
             this.showReferenceText();
         } else {
-            this.setInActiveIcon();
             this.hideReferenceText();
         }
     }

--- a/src/sdg/js/components/form/toggle.js
+++ b/src/sdg/js/components/form/toggle.js
@@ -37,13 +37,13 @@ class FormToggle extends FormComponent {
      * Returns an HTMLElement representing the scope of the toggle.
      * For an "edit all" toggle the form is considered to be the scope, for an "edit control" toggle the form control is
      * considered to be the element scope.
-     * @return {(HTMLElement|HTMLFormElement)}
+     * @return {([HTMLElement]|[HTMLFormElement])}
      */
     getElementScope() {
         try {
-            return this.getFormControl();
+            return [this.getFormControl()];
         } catch (e) {
-            return this.node.form;
+            return this.node.form.querySelectorAll('.form__cell');
         }
     }
 
@@ -53,35 +53,11 @@ class FormToggle extends FormComponent {
      * Use this to persist (read only) state to DOM.
      * @param {Object} state Read only state.
      */
-    render({editable}) {
+    render(state) {
+        const {editable} = state;
         const elementScope = this.getElementScope();
 
-        // Update the current element.
-        this.node.checked = editable;
-
-        // Update synced elements.
-        try {
-            this.getFormControl();  // Use as indicator whether toggle is bound to form control, raises error if not.
-        } catch (e) {
-            [...this.node.form.querySelectorAll('.toggle input')].forEach((toggle) => toggle.checked = editable);
-        }
-
-        // Set readonly.
-        [...elementScope.querySelectorAll(`
-            .form__cell input,
-            .form__cell select,
-            .form__cell textarea
-        `)].forEach((field) => {
-            const formControl = this.getFormControl(field);
-            formControl.classList.toggle('form__cell--disabled', !editable);
-            field.readOnly = !editable;
-        });
-
-        // Set disabled.
-        [...elementScope.querySelectorAll(
-            '.form__cell .button-group .button'
-        )].forEach((button) => button.disabled = !editable);
-
+        [...elementScope].forEach((formControl) => this.setFormControlDisabled(!editable, formControl));
     }
 }
 

--- a/src/sdg/js/components/form/use_reference_button.js
+++ b/src/sdg/js/components/form/use_reference_button.js
@@ -1,4 +1,4 @@
-import {FormComponent} from './abstract/form_component';
+import {ReferenceTextComponent} from './abstract/reference_text_component';
 
 
 /** @type {NodeListOf<HTMLAnchorElement>} */
@@ -8,7 +8,7 @@ const USE_REFERENCE_BUTTONS = document.querySelectorAll('.form__reference-btn');
 /**
  * Button allow the user to use the reference text.
  */
-class UseReferenceButton extends FormComponent {
+class UseReferenceButton extends ReferenceTextComponent {
     /**
      * Gets called when this.node gets clicked.
      * @param {MouseEvent} event
@@ -16,6 +16,19 @@ class UseReferenceButton extends FormComponent {
     onClick(event) {
         event.preventDefault();
         this.setValue(this.getPreviousVersionData().input.value);
+    }
+
+    /**
+     * Updates the label state based on disabled attribute.
+     */
+    updateLabel() {
+        super.updateLabel();
+
+        if(this.getFormControlDisabled()) {
+            this.setState({label: 'Aanpassen uitgeschakeld'});
+        } else {
+            this.setState({label: this.state.originalLabel});
+        }
     }
 }
 

--- a/src/sdg/scss/_settings.scss
+++ b/src/sdg/scss/_settings.scss
@@ -52,7 +52,7 @@ $grid-container-size: $breakpoint-desktop - 2 * $grid-container-margin !default;
 $grid-container-size-small: 800px !default;
 $grid-container-size-big: 1400px !default;
 $grid-margin-0: 5px !default;
-$grid-margin-1: 10px !default;
+$grid-margin-1: 12px;
 $grid-margin-2: 20px !default;
 $grid-margin-3: 30px !default;
 $grid-margin-4: 40px !default;

--- a/src/sdg/scss/components/_button.scss
+++ b/src/sdg/scss/components/_button.scss
@@ -1,4 +1,5 @@
 @import "colors";
+@import '~microscope-sass/lib/animation';
 
 .button {
   --main-color: #{$color_accent};
@@ -62,6 +63,7 @@
   }
 
   .svg-inline--fa {
+    @include animate;
     color: var(--text-color);
     margin: 0 4px;
   }

--- a/src/sdg/scss/components/_ckeditor.scss
+++ b/src/sdg/scss/components/_ckeditor.scss
@@ -1,5 +1,9 @@
 @import 'colors';
 
+.ck {
+  --ck-color-toolbar-background: $color_grey_lightest;
+}
+
 .ck-content {
   transition: background-color .3s ease-in-out;
 

--- a/src/sdg/scss/components/_dynamic.scss
+++ b/src/sdg/scss/components/_dynamic.scss
@@ -19,7 +19,6 @@
 
     .dynamic__container__button {
       border: none;
-      color: $color_secondary_lightest;
       padding: 6px;
       cursor: pointer;
 
@@ -30,17 +29,6 @@
         right: 24px;
         color: $color_secondary_darkest;
       }
-
-      &--low {
-        @extend .dynamic__container__button;
-        background-color: transparent;
-        color: $color_secondary_darkest;
-        font-weight: bold;
-        margin-right: 10px;
-        margin-top: 3px;
-        width: 98%;
-      }
-
     }
 
   }

--- a/src/sdg/scss/components/_highlight.scss
+++ b/src/sdg/scss/components/_highlight.scss
@@ -1,0 +1,21 @@
+@import '../settings';
+@import './colors';
+
+.highlight {
+  --border-color: #{$color_grey_light};
+  --border-size: #{$typography-size-border};
+  --main-color: #{$color_white};
+  --spacing: #{$grid-margin-1};
+  background-color: var(--main-color);
+  border: var(--border-size) solid var(--border-color);
+  padding: var(--spacing);
+
+  &[aria-hidden=true] {
+    display: none;
+    visibility: hidden;
+  }
+
+  &:empty {
+    display: none;
+  }
+}

--- a/src/sdg/scss/components/_index.scss
+++ b/src/sdg/scss/components/_index.scss
@@ -1,4 +1,5 @@
 // Use this file to include individual components.
+@import 'highlight';
 @import 'rijkshuisstijl';
 @import 'button-group';
 @import 'login';

--- a/src/sdg/scss/components/_tabs.scss
+++ b/src/sdg/scss/components/_tabs.scss
@@ -92,12 +92,12 @@
     font-weight: bold;
     text-align: left;
     border-bottom: 1px solid #BDBDBD;
-    padding: 12px 12px 12px 0;
+    padding: 12px 0;
     text-transform: uppercase;
   }
 
   .tabs__table-cell {
-    padding: 12px 12px 12px 0;
+    padding: 12px 0;
     border-bottom: 1px solid #BDBDBD;
     vertical-align: top;
     line-height: 1.5;

--- a/src/sdg/scss/components/_toggle.scss
+++ b/src/sdg/scss/components/_toggle.scss
@@ -8,63 +8,73 @@ $toggle-track-height: $grid-margin-2 - 2 * $typography-size-border;
 $toggle-track-width: $toggle-track-height * 2;
 
 .toggle {
+  --active-color: #{$color_accent_light};
+  --border-size: #{$typography-size-border};
+  --label-color: currentColor;
   --main-color: #{$color_secondary_light};
   --shadow-color: #{$color_grey_dark};
-  @include animate;
+  --track-color: transparent;
+  --track-height: #{$grid-margin-2 - 2 * $typography-size-border};
+  --track-margin: #{$grid-margin-1};
+  --track-width: #{$toggle-track-width};
+
   align-items: center;
   display: flex;
-  gap: $grid-margin-1;
+  gap: var(--track-margin);
   justify-content: space-between;
   width: auto;
-
-  &__label {
-  }
 
   &__checkbox {
     position: absolute;
     opacity: 0;
   }
 
-  &__checkbox:checked + &__handle {
-    background-color: $color_accent_light;
-    justify-content: flex-end;
-  }
-
-  &__checkbox:focus + &__handle:before {
-    box-shadow: 0px 0px 4px 4px $color_primary_lighter;
-  }
-
   &__handle {
-    border: $typography-size-border solid var(--shadow-color);
-    border-radius: $toggle-track-width;
+    @include animate;
+    background-color: var(--track-color);
+    border: var(--border-size) solid var(--shadow-color);
+    border-radius: var(--track-width);
     box-shadow: inset 1px 1px 2px var(--shadow-color);
     box-sizing: content-box;
     color: var(--main-color);
     cursor: pointer;
-    display: flex;
     flex-shrink: 0;
     font-size: 0;
-    justify-content: flex-start;
     position: relative;
-    height: $toggle-track-height;
-    width: $toggle-track-width;
+    height: var(--track-height);
+    width: var(--track-width);
+  }
+
+  &__checkbox:checked + &__handle {
+    --track-color: var(--active-color);
   }
 
   &__handle:before {
-    $handle_size: $toggle-track-height;
+    @include animate;
     @include rounded;
-    @include scale(1.1, 1.1);
     background-color: currentColor;
-    border: $typography-size-border solid transparent;
+    border: var(--border-size) solid transparent;
     box-shadow: 1px 1px 4px var(--shadow-color);
     box-sizing: border-box;
     content: '';
     display: block;
-    height: $toggle-track-height;
-    width: $toggle-track-height;
+    height: var(--track-height);
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: var(--track-height);
   }
 
-  & &__label .svg-inline--fa {
-    color: $color_grey_darkest;
+  &__checkbox:checked + &__handle:before {
+    transform: translateX(calc(var(--track-width) / 2));
+  }
+
+
+  &__checkbox:focus + &__handle:before {
+    box-shadow: 0px 0px 4px 4px var(--shadow-color);
+  }
+
+  & &__label {
+    color: var(--label-color);
   }
 }

--- a/src/sdg/scss/components/_toolbar.scss
+++ b/src/sdg/scss/components/_toolbar.scss
@@ -1,5 +1,23 @@
 .toolbar {
+  --border-color: transparent;
+  --border-size: #{$typography-size-border};
+  --main-color: transparent;
+  --spacing: #{$grid-margin-1} 0;
+
+  background-color: var(--main-color);
+  border: var(--border-size) solid var(--border-color);
   display: flex;
   justify-content: space-between;
-  margin: 12px 0;
+  padding: var(--spacing);
+
+  &[aria-hidden=true] {
+    display: none;
+    visibility: hidden;
+  }
+
+  &--dark {
+      --border-color: #{$color_grey_light};
+      --main-color: #{$color_grey_lightest};
+      --spacing: #{$grid-margin-1};
+  }
 }

--- a/src/sdg/templates/forms/table_field.html
+++ b/src/sdg/templates/forms/table_field.html
@@ -1,4 +1,4 @@
-{% load toggle utils i18n %}
+{% load i18n toggle utils %}
 
 {% with configuration=field.configuration.0 %}
     <tr>
@@ -13,28 +13,32 @@
                     {{ field|addclass:"form__input" }}
                 </div>
                 {{ field.errors }}
-                    <div class="toolbar">
+                {% if not is_reference %}
+                    <footer class="toolbar">
+                        <button class="button button--light button--small form__display-btn" type="button">
+                            <i class="fa fa-chevron-right"></i>
+                            {% trans 'Toon standaardtekst' %}
+                        </button>
+                        {% toggle _('Aanpassen') hide_label=True icon_before='lock' icon_after='lock-open' %}
+                    </footer>
+
+                    <aside class="highlight form__reference"></aside>
+                    <footer class="toolbar toolbar--dark">
                         <div class="button-group">
-                            {% if not is_reference %}
-                            <button class="button button--light button--small form__diff-btn" type="button"
+                            <button class="button button--light button--small form__diff-btn"
+                                    type="button"
                                     title="{% trans "Toon wijzigingen in standaard tekst t.o.v. vorige versie" %}">
                                 <i class="fa fa-eye fa-xs"></i>
-                                {% trans "Vergelijken" %}
-                            </button>
-
-                            <button class="button button--light button--small form__display-btn" type="button">
-                                <i class="fa fa-chevron-right"></i>
-                                {% trans "Toon standaardtekst" %}
+                                {% trans 'Vergelijken' %}
                             </button>
 
                             <button class="button button--light button--small form__reference-btn" type="button">
                                 <i class="fa fa-undo fa-xs"></i>
-                                {% trans "Gebruik standaardtekst" %}
+                                {% trans 'Gebruik standaardtekst' %}
                             </button>
-                            {% endif %}
                         </div>
-                        {% toggle _('Bewerken') hide_label=True icon_before='lock' icon_after='lock-open' %}
-                    </div>
+                    </footer>
+                {% endif %}
             {% endif %}
         </td>
     </tr>

--- a/src/sdg/templates/forms/widgets/dynamic_array.html
+++ b/src/sdg/templates/forms/widgets/dynamic_array.html
@@ -6,7 +6,8 @@
         <div class="dynamic__container">
             <div>
                 {% for subwidget in widget.subwidgets %}
-                    <div class="dynamic__container-item" {% if widget.is_none %}data-isNone="true" style="display: none"{% endif %}>
+                    <div class="dynamic__container-item" {% if widget.is_none %}data-isNone="true"
+                         style="display: none"{% endif %}>
                         {% with widget=subwidget %}
                             {% include widget.template_name %}
                         {% endwith %}
@@ -19,7 +20,12 @@
                 {% endfor %}
             </div>
             {% if not widget.single %}
-                <div><input type="button" class="dynamic__container__button--low dynamic__container-add" value="{% trans "Toevoegen" %}"></div>
+                <div class="toolbar">
+                    <button class="button button--light button--small dynamic__container-add" type="button">
+                        <i class="fa fa-plus fa-xs"></i>
+                        {% trans "Toevoegen" %}
+                    </button>
+                </div>
             {% endif %}
         </div>
     </div>

--- a/src/sdg/templates/producten/update.html
+++ b/src/sdg/templates/producten/update.html
@@ -19,12 +19,6 @@
             {{ reference_form.as_p }}
         </template>
     {% endfor %}
-
-    <template class="form__reference--display-template">
-        <div class="reference__display form__input form__input--disabled">
-            <div class="reference__display--content"></div>
-        </div>
-    </template>
 {% endblock %}
 
 {% block inner_content %}


### PR DESCRIPTION
Fixes #454

_______

**Changes**

- Move "Gebruik standaardtekst" under the "Toon standaardtekst" block.
- Add label (Toon wijzigingen t.o.v. vorige versie) after eye-icon, and move the eye-function to the bottom next to "Gebruik standaard tekst".

