### PR TITLE
Rename catalogi to productenlijst

### DIFF
--- a/src/sdg/organisaties/urls/__init__.py
+++ b/src/sdg/organisaties/urls/__init__.py
@@ -5,8 +5,8 @@ app_name = "organisaties"
 urlpatterns = [
     path("", include("sdg.organisaties.urls.overheid")),
     url(
-        r"^(?P<pk>[\d]+)/catalogs/",
-        include("sdg.organisaties.urls.catalog", namespace="catalogi"),
+        r"^(?P<pk>[\d]+)/productenlijst/",
+        include("sdg.organisaties.urls.catalog", namespace="productenlijst"),
     ),
     url(
         r"^(?P<pk>[\d]+)/roles/",

--- a/src/sdg/templates/core/base.html
+++ b/src/sdg/templates/core/base.html
@@ -14,7 +14,7 @@
                         <a href="{% url 'organisaties:catalogi:list' pk=kwargs.pk %}">{{ lokaleoverheid }}</a>
                     {% endif %}
                     {% if kwargs.catalog_pk %}
-                        <a href="{% url 'organisaties:catalogi:list' pk=kwargs.pk %}">{% trans 'Catalogi' %}</a>
+                        <a href="{% url 'organisaties:catalogi:list' pk=kwargs.pk %}">{% trans 'Productenlijst' %}</a>
                     {% endif %}
                 {% endwith %}
                 {% if namespace == "roles" %}


### PR DESCRIPTION
Fixes #413

_______

**Changes**

- Update front-facing text for CMS: 'catalogi' → 'productenlijst'