### PR TITLE
Limit markdown editor headings

### DIFF
--- a/src/sdg/js/components/ckeditor.js
+++ b/src/sdg/js/components/ckeditor.js
@@ -33,6 +33,13 @@ ClassicEditor.builtinPlugins = [
 ];
 
 ClassicEditor.defaultConfig = {
+    heading: {
+        options: [
+            {model: 'paragraph', title: 'Paragraaf', class: 'ck-heading_paragraph'},
+            {model: 'heading1', view: 'h3', title: 'Kop 1', class: 'ck-heading_heading1'},
+            {model: 'heading2', view: 'h4', title: 'Kop 2', class: 'ck-heading_heading2'}
+        ]
+    },
     toolbar: {
         items: [
             'heading',


### PR DESCRIPTION
Fixes #472

_______

**Changes**

- Limit markdown editor headings to h3 and h4
- 
![Peek 2022-03-25 16-38](https://user-images.githubusercontent.com/58147939/160153572-e279b240-b79e-457d-a2d5-b846f8c4bdea.gif)

