### PR TITLE
:lipstick: [#524] relocated the publicatie datum error message

### DIFF
--- a/src/sdg/scss/components/_toolbar.scss
+++ b/src/sdg/scss/components/_toolbar.scss
@@ -28,4 +28,15 @@
     bottom: 0;
     z-index: 100;
   }
+
+  &--column {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &--row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
 }

--- a/src/sdg/templates/producten/update.html
+++ b/src/sdg/templates/producten/update.html
@@ -205,31 +205,37 @@
             {% endif %}
         </div>
 
-
-        <div class="toolbar toolbar--sticky-b">
-            <div class="toolbar__section">
-                <div class="calendar-container">
-                    {{ version_form.non_field_errors }}
-                    {% trans "Publicatie datum" %}
-                    <input name="date" type="date" class="calendar form__input"
-                           value="{{ version_form.date.initial }}">
-                </div>
+        <div class="toolbar toolbar--sticky-b toolbar--column">
+            {% if version_form.non_field_errors %}
+            <div class="toolbar--row error">
+                {{ version_form.non_field_errors }}
             </div>
+            {% endif %}
 
-            <div class="toolbar__section">
-                <div class="button-group">
-                    <a href="{% url 'organisaties:catalogi:producten:edit' pk=lokaleoverheid.pk catalog_pk=product.catalogus.pk product_pk=product.pk %}">
-                        <button type="button" class="button button--light">{% trans 'Annuleren' %}</button>
-                    </a>
+            <div class="toolbar__section toolbar--row form">
+                <div class="toolbar__section">
+                    <div class="calendar-container">
+                        {% trans "Publicatie datum" %}
+                        <input name="date" type="date" class="calendar form__input"
+                                value="{{ version_form.date.initial }}">
+                    </div>
+                </div>
 
-                    <button class="button tabs__form-button button--light" name="publish" value="concept"
-                            type="submit">
-                        Opslaan als concept
-                    </button>
+                <div class="toolbar__section">
+                    <div class="button-group">
+                        <a href="{% url 'organisaties:catalogi:producten:edit' pk=lokaleoverheid.pk catalog_pk=product.catalogus.pk product_pk=product.pk %}">
+                            <button type="button" class="button button--light">{% trans 'Annuleren' %}</button>
+                        </a>
 
-                    <button class="button tabs__form-button" type="submit" name="publish" value="date">
-                        Opslaan en publiceren
-                    </button>
+                        <button class="button tabs__form-button button--light" name="publish" value="concept"
+                                type="submit">
+                            Opslaan als concept
+                        </button>
+
+                        <button class="button tabs__form-button" type="submit" name="publish" value="date">
+                            Opslaan en publiceren
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixes #524

_______

**Changes**
relocated the publicatie datum error message from the left side of the field to be above the field

from:
![Screenshot from 2022-04-08 15-01-53](https://user-images.githubusercontent.com/101265650/162700307-22b2aff7-cbdf-437a-9c1f-86f8553fcb30.png)

to:
![Screenshot from 2022-04-11 10-51-19](https://user-images.githubusercontent.com/101265650/162700515-8eb949d0-70e6-4bdb-ac88-b6840904054e.png)


