### PR TITLE
:lipstick: [547] moved the toelichtingen fields to be under the pulldowns

### DIFF
--- a/src/sdg/producten/views/product.py
+++ b/src/sdg/producten/views/product.py
@@ -279,8 +279,6 @@ class ProductUpdateView(OverheidMixin, UpdateView):
             "uiterste_termijn",
             "wtd_bij_geen_reactie",
             "decentrale_procedure_link",
-            "product_valt_onder_toelichting",
-            "product_aanwezig_toelichting",
         ]
         return context
 

--- a/src/sdg/templates/producten/update.html
+++ b/src/sdg/templates/producten/update.html
@@ -52,67 +52,125 @@
                         <i class="fa fa-chevron-right bem-toggle__icon"></i>
                         {% trans "Algemene Gegevens" %}
                     </th>
-                    <th class="tabs__table-header"></th>
                 </tr>
-            </thead>
-            <tbody class="tabs__table-body">
-                <tr>
-                </tr>
+                </thead>
+                <tbody class="tabs__table-body">
 
                 {% if not product.is_referentie_product %}
-                {% with field=product_form.product_aanwezig %}
-                <tr>
-                    <td class="tabs__table-cell" width="25%"> {{ field.label|capfirst }} <i
-                            class="fas fa-info-circle fa-xs dark" title="{{ field.help_text }}"></i> </td>
-                    <td class="tabs__table-cell"> {% select field %} {{ field.errors }} </td>
-                </tr>
-                {% endwith %}
+                    {% with field=product_form.product_aanwezig %}
+                    <tr>
+                        <td>
+                            <div class="form__control">
+                                <header class="form__control-header">
+                                    <label class="form__label">
+                                        {{ field.label|capfirst }}
+                                        <i class="fas fa-info-circle fa-xs dark" title="{{ field.help_text }}"></i>
+                                    </label>
+                                </header>
+                                <div class="form__control-body">
+                                    <div class="tabs__table-cell--versions"></div>
+                                    {% select field %}
+                                    {{ field.errors }}
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    {% endwith %}
 
-                {% with field=product_form.product_valt_onder %}
-                <tr>
-                    <td class="tabs__table-cell" width="25%">{{ field.label|capfirst }}<i
-                            class="fas fa-info-circle fa-xs dark" title="{{ field.help_text }}"></i></td>
-                    <td class="tabs__table-cell">{% select field %}{{ field.errors }} </td>
-                </tr>
-                {% endwith %}
+                    <tr>
+                        <td>
+                            {% localized_form formset include_form=False fields="product_aanwezig_toelichting" %}
+                        </td>
+                    </tr>
 
-                {% with field=product_form.bevoegde_organisatie %}
-                {% with configuration=field.configuration.0 %}
-                <tr>
-                    <td class="tabs__table-cell" width="25%">{{ configuration.0|default:field.label|capfirst }}<i
-                            class="fas fa-info-circle fa-xs dark"
-                            title="{{ configuration.1|default:field.help_text }}"></i>
-                    </td>
-                    <td class="tabs__table-cell">
-                        {% select field %}
-                        {{ field.errors }}
-                    </td>
-                </tr>
-                {% endwith %}
-                {% endwith %}
+                    {% with field=product_form.product_valt_onder %}
+                    <tr>
+                        <td>
+                            <div class="form__control">
+                                <header class="form__control-header">
+                                    <label class="form__label">
+                                        {{ field.label|capfirst }}
+                                        <i class="fas fa-info-circle fa-xs dark" title="{{ field.help_text }}"></i>
+                                    </label>
+                                </header>
+                                <div class="form__control-body">
+                                    <div class="tabs__table-cell--versions"></div>
+                                    {% select field %}
+                                    {{ field.errors }}
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    {% endwith %}
 
-                {% with field=product_form.locaties %}
-                <tr>
-                    <td class="tabs__table-cell" width="25%"> {{ field.label|capfirst }}
-                        <i class="fas fa-info-circle fa-xs dark" title="{{ field.help_text }}"></i>
-                    </td>
-                    <td class="tabs__table-cell"> {{ field }} {{ field.errors }} </td>
-                </tr>
-                {% endwith %}
+                    <tr>
+                        <td>
+                            {% localized_form formset include_form=False fields="product_valt_onder_toelichting" %}
+                        </td>
+                    </tr>
+
+                    {% with field=product_form.bevoegde_organisatie %}
+                        {% with configuration=field.configuration.0 %}
+                            <tr>
+                                <td>
+                                    <div class="form__control">
+                                        <header class="form__control-header">
+                                            <label class="form__label">
+                                                {{ configuration.0|default:field.label|capfirst }}
+                                                <i class="fas fa-info-circle fa-xs dark" title="{{ configuration.1|default:field.help_text }}"></i>
+                                            </label>
+                                        </header>
+                                        <div class="form__control-body">
+                                            <div class="tabs__table-cell--versions"></div>
+                                            {% select field %}
+                                            {{ field.errors }}
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                        {% endwith %}
+                    {% endwith %}
+
+                    {% with field=product_form.locaties %}
+                    <tr>
+                        <td>
+                            <div class="form__control">
+                                <header class="form__control-header">
+                                    <label class="form__label">
+                                        {{ field.label|capfirst }}
+                                        <i class="fas fa-info-circle fa-xs dark" title="{{ field.help_text }}"></i>
+                                    </label>
+                                </header>
+                                <div class="form__control-body">
+                                    <div class="tabs__table-cell--versions"></div>
+                                    {{ field }}
+                                    {{ field.errors }}
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    {% endwith %}
                 {% endif %}
 
                 {% with publication_date=product.active_version|get_field:"publicatie_datum" %}
-                {% with configuration=publication_date.configuration.0 %}
-                <tr>
-                    <td class="tabs__table-cell">{{ configuration.0|default:_("Publicatie datum")|capfirst }}<i
-                            class="fas fa-info-circle fa-xs dark"
-                            title="{{ configuration.1|default:_('Publicatiedatum van de productversie') }}"></i>
-                    </td>
-                    <td class="tabs__table-cell">
-                        <span class="tabs__table-cell--value">{{ publication_date.value|default:"Concept" }}</span>
-                    </td>
-                </tr>
-                {% endwith %}
+                    {% with configuration=publication_date.configuration.0 %}
+                        <tr>
+                            <td>
+                                <div class="form__control">
+                                    <header class="form__control-header">
+                                        <label class="form__label">
+                                            {{ configuration.0|default:_("Publicatie datum")|capfirst }}
+                                            <i class="fas fa-info-circle fa-xs dark" title="{{ configuration.1|default:_('Publicatiedatum van de productversie') }}"></i>
+                                        </label>
+                                    </header>
+                                    <div class="form__control-body">
+                                        <div class="tabs__table-cell--versions"></div>
+                                        <span class="tabs__table-cell--value">{{ publication_date.value|default:"Concept" }}</span>
+                                    </div>
+                                </div>
+                            </td>
+                        </tr>
+                    {% endwith %}
                 {% endwith %}
 
             </tbody>


### PR DESCRIPTION
Fixes #547 

_______

**Changes**

- changed the layout of the Algemene Gegevens to match the "localized_form.html"
- added localized_form in the Algemene Gegevens for the fields "product_valt_onder_toelichting" and "product_aanwezig_toelichting"
- Removed "product_aanwezig_toelichting" and "product_valt_onder_toelichting"  from the "localized_form_fields" context
- changed the generic.js to triger the displayFunc for the setUpDynamicProductAanwezig when the domContent is loaded
