### PR TITLE
:bug:[538] added css to render the language button element correctly on firefox

### DIFF
--- a/src/sdg/scss/components/_form.scss
+++ b/src/sdg/scss/components/_form.scss
@@ -30,8 +30,12 @@
     margin: 0 4px;
   }
 
-  &__language-switch .svg-inline--fa {
-    color: $color_red!important;
+  &__language-switch {
+    white-space: nowrap;
+
+    .svg-inline--fa {
+      color: $color_red!important;
+    }
   }
 
   &__control-body {


### PR DESCRIPTION
Fixes #538

_______

**Changes**

Added white-space: nowrap to the _form.scss for the language-switch
