### PR TITLE
:lipstick:[559] added standard lables for algemene gegevens

### DIFF
--- a/src/sdg/producten/forms.py
+++ b/src/sdg/producten/forms.py
@@ -101,6 +101,9 @@ class ProductForm(FieldConfigurationMixin, forms.ModelForm):
             "locaties",
         )
 
+    def _help_text(self, field):
+        return Product._meta.get_field(field).help_text
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         locations = self.instance.get_municipality_locations()
@@ -114,6 +117,10 @@ class ProductForm(FieldConfigurationMixin, forms.ModelForm):
         self.fields["bevoegde_organisatie"].queryset = self.fields[
             "bevoegde_organisatie"
         ].queryset.filter(lokale_overheid=self.instance.catalogus.lokale_overheid)
+
+        for field in self.fields:
+            self.fields[field].help_text = self._help_text(field)
+
         self.configure_fields()
 
 

--- a/src/sdg/templates/forms/table_row.html
+++ b/src/sdg/templates/forms/table_row.html
@@ -16,7 +16,7 @@
                 {% else %}
                 {{ field.verbose_name|capfirst }}
                 {% endif %}
-                <i class="fas fa-info-circle fa-xs dark" title="{{ field.help_text }}"></i>
+                <i class="fas fa-info-circle fa-xs dark" title="{{ field.configuration.0.1|default:field.help_text }}"></i>
             </label>
         </header>
         {#  Form control body. #}


### PR DESCRIPTION
Fixes #559 

_______

**Changes**

Added function to get the helptext for the productform
Set the default helptext to the helptext devinded in the product models

