### PR TITLE
Feature/605 toelichtingvelden gebruiken nederlandse product namen

### DIFF
--- a/src/sdg/cmsapi/apps.py
+++ b/src/sdg/cmsapi/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class CmsapiConfig(AppConfig):
+    name = "sdg.cmsapi"

--- a/src/sdg/cmsapi/serializers.py
+++ b/src/sdg/cmsapi/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+
 from sdg.producten.models.localized import LocalizedGeneriekProduct
 
 

--- a/src/sdg/cmsapi/serializers.py
+++ b/src/sdg/cmsapi/serializers.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+from sdg.producten.models.localized import LocalizedGeneriekProduct
+
+
+class LocalizedGenericProductSerializer(serializers.ModelSerializer):
+    generiek_product = serializers.CharField(read_only=True)
+    product_titel = serializers.CharField(read_only=True)
+
+    class Meta:
+        model = LocalizedGeneriekProduct
+        fields = (
+            "taal",
+            "generiek_product",
+            "product_titel",
+        )

--- a/src/sdg/cmsapi/tests.py
+++ b/src/sdg/cmsapi/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/src/sdg/cmsapi/tests.py
+++ b/src/sdg/cmsapi/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/src/sdg/cmsapi/tests/test_api.py
+++ b/src/sdg/cmsapi/tests/test_api.py
@@ -1,0 +1,185 @@
+from datetime import date
+
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from sdg.accounts.tests.factories import UserFactory
+from sdg.core.tests.factories.catalogus import ProductenCatalogusFactory
+from sdg.organisaties.tests.factories.overheid import (
+    BevoegdeOrganisatieFactory,
+    LokaleOverheidFactory,
+)
+from sdg.producten.tests.factories.localized import (
+    LocalizedGeneriekProductFactory,
+    LocalizedProductFactory,
+)
+from sdg.producten.tests.factories.product import (
+    GeneriekProductFactory,
+    ProductFactory,
+    ProductVersieFactory,
+    ReferentieProductFactory,
+)
+
+
+class ProductTranslationTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory.create(
+            email="test@email.com",
+            password="h@1221$@fwDDW#3",
+        )
+
+        self.generic_product = GeneriekProductFactory.create()
+        self.generic_localized_product_nl = LocalizedGeneriekProductFactory.create(
+            generiek_product=self.generic_product, taal="nl"
+        )
+        self.generic_localized_product_en = LocalizedGeneriekProductFactory.create(
+            generiek_product=self.generic_product, taal="en"
+        )
+
+        self.ref_overheid = LokaleOverheidFactory.create(
+            automatisch_catalogus_aanmaken=False
+        )
+        self.ref_catalog = ProductenCatalogusFactory.create(
+            lokale_overheid=self.ref_overheid,
+            is_referentie_catalogus=True,
+        )
+        self.ref_product = ReferentieProductFactory.create(
+            catalogus=self.ref_catalog,
+            generiek_product=self.generic_product,
+        )
+        self.ref_product_versie = ProductVersieFactory.create(
+            product=self.ref_product,
+            publicatie_datum=date.today(),
+        )
+        self.ref_localized_product_nl = LocalizedProductFactory.create(
+            product_versie=self.ref_product_versie,
+            taal="nl",
+        )
+        self.ref_localized_product_en = LocalizedProductFactory.create(
+            product_versie=self.ref_product_versie,
+            taal="en",
+        )
+
+        self.overheid = LokaleOverheidFactory.create(
+            automatisch_catalogus_aanmaken=True
+        )
+        self.catalog = ProductenCatalogusFactory.create(
+            lokale_overheid=self.overheid,
+            is_referentie_catalogus=False,
+        )
+        self.bevoegde_organisatie = BevoegdeOrganisatieFactory.create(
+            lokale_overheid=self.catalog.lokale_overheid,
+            organisatie=None,
+        )
+        self.product = ProductFactory.create(
+            catalogus=self.catalog,
+            generiek_product=self.generic_product,
+            referentie_product=self.ref_product,
+            bevoegde_organisatie=self.bevoegde_organisatie,
+        )
+        self.product_versie = ProductVersieFactory.create(
+            product=self.product,
+            publicatie_datum=date.today(),
+        )
+        self.localized_product_nl = LocalizedProductFactory.create(
+            product_versie=self.product_versie,
+            taal="nl",
+        )
+        self.localized_product_en = LocalizedProductFactory.create(
+            product_versie=self.product_versie,
+            taal="en",
+        )
+
+    def test_api_call_with_no_params_while_logged_in(self):
+        self.client.force_authenticate(user=self.user)
+
+        list_url = reverse(
+            "cmsapi:translation-list",
+        )
+        response = self.client.get(list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+        self.assertEqual(0, len(data))
+
+    def test_api_call_with_no_params_while_logged_out(self):
+        list_url = reverse("cmsapi:translation-list")
+        response = self.client.get(list_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_api_call_with_existing_product_id(self):
+        self.client.force_authenticate(user=self.user)
+
+        list_url = reverse("cmsapi:translation-list")
+
+        response = self.client.get(f"{list_url}?product_id={self.product.id}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+        self.assertEqual(2, len(data))
+        self.assertEqual(
+            str(data[0]["generiekProduct"]),
+            str(self.generic_localized_product_nl.generiek_product),
+        )
+        self.assertEqual(
+            str(data[1]["generiekProduct"]),
+            str(self.generic_localized_product_en.generiek_product),
+        )
+
+    def test_api_call_with_none_existing_product_id(self):
+        self.client.force_authenticate(user=self.user)
+
+        list_url = reverse("cmsapi:translation-list")
+
+        response = self.client.get(f"{list_url}?product_id={self.product.id + 1}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+        self.assertEqual(0, len(data))
+
+    def test_api_call_with_existing_product_id_and_none_existing_taal(self):
+        self.client.force_authenticate(user=self.user)
+
+        list_url = reverse("cmsapi:translation-list")
+
+        response = self.client.get(f"{list_url}?product_id={self.product.id}&taal=uk")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+        self.assertEqual(0, len(data))
+
+    def test_api_call_with_existing_taal_and_none_existing_product_id(self):
+        self.client.force_authenticate(user=self.user)
+
+        list_url = reverse("cmsapi:translation-list")
+
+        response = self.client.get(
+            f"{list_url}?product_id={self.product.id + 1}&taal=nl"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+        self.assertEqual(0, len(data))
+
+    def test_api_call_with_existing_product_id_and_taal(self):
+        self.client.force_authenticate(user=self.user)
+
+        list_url = reverse("cmsapi:translation-list")
+
+        response = self.client.get(f"{list_url}?product_id={self.product.id}&taal=nl")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+        self.assertEqual(1, len(data))
+        self.assertEqual(
+            str(data[0]["generiekProduct"]),
+            str(self.generic_localized_product_nl.generiek_product),
+        )

--- a/src/sdg/cmsapi/urls.py
+++ b/src/sdg/cmsapi/urls.py
@@ -1,0 +1,12 @@
+from django.urls import include, path
+from rest_framework import routers
+from sdg.cmsapi import views
+
+app_name = "cmsapi"
+
+router = routers.DefaultRouter(trailing_slash=False)
+router.register("translation/", views.ProductTranslation)
+
+urlpatterns = [
+    path("", include(router.urls)),
+]

--- a/src/sdg/cmsapi/urls.py
+++ b/src/sdg/cmsapi/urls.py
@@ -1,11 +1,13 @@
 from django.urls import include, path
+
 from rest_framework import routers
+
 from sdg.cmsapi import views
 
 app_name = "cmsapi"
 
 router = routers.DefaultRouter(trailing_slash=False)
-router.register("translation/", views.ProductTranslation)
+router.register("translation/", views.ProductTranslation, basename="translation")
 
 urlpatterns = [
     path("", include(router.urls)),

--- a/src/sdg/cmsapi/views.py
+++ b/src/sdg/cmsapi/views.py
@@ -3,7 +3,7 @@ from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 
 from sdg.cmsapi.serializers import LocalizedGenericProductSerializer
-from sdg.producten.models.localized import LocalizedProduct, LocalizedGeneriekProduct
+from sdg.producten.models.localized import LocalizedGeneriekProduct, LocalizedProduct
 
 
 class ProductTranslation(viewsets.ReadOnlyModelViewSet):
@@ -12,6 +12,7 @@ class ProductTranslation(viewsets.ReadOnlyModelViewSet):
     authentication_classes = [SessionAuthentication]
     permission_classes = [IsAuthenticated]
     lookup_url_kwargs = ["product_id", "taal"]
+    schema = None
 
     def get_queryset(self):
         product_id = self.request.query_params.get("product_id", None)

--- a/src/sdg/cmsapi/views.py
+++ b/src/sdg/cmsapi/views.py
@@ -1,0 +1,35 @@
+from rest_framework import viewsets
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.permissions import IsAuthenticated
+
+from drf_spectacular.utils import extend_schema, extend_schema_view
+
+from sdg.cmsapi.serializers import (
+    LocalizedGenericProductSerializer,
+)
+from sdg.producten.models.localized import LocalizedProduct, LocalizedGeneriekProduct
+
+
+@extend_schema_view(
+    retrieve=extend_schema(description="Generiek product"),
+)
+class ProductTranslation(viewsets.ReadOnlyModelViewSet):
+    queryset = LocalizedProduct.objects.none()
+    serializer_class = LocalizedGenericProductSerializer
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+    lookup_url_kwargs = "product_id"
+
+    def get_queryset(self):
+        product_id = self.request.query_params.get("product_id", None)
+        localized_products = (
+            LocalizedProduct.objects.filter(
+                product_versie__product__id=product_id,
+                taal="nl",
+            )
+            .order_by("product_versie")
+            .first()
+        )
+        return LocalizedGeneriekProduct.objects.filter(
+            generiek_product=localized_products.product_versie.product.referentie_product.generiek_product
+        )

--- a/src/sdg/cmsapi/views.py
+++ b/src/sdg/cmsapi/views.py
@@ -18,10 +18,12 @@ class ProductTranslation(viewsets.ReadOnlyModelViewSet):
     serializer_class = LocalizedGenericProductSerializer
     authentication_classes = [SessionAuthentication]
     permission_classes = [IsAuthenticated]
-    lookup_url_kwargs = "product_id"
+    lookup_url_kwargs = ["product_id", "taal"]
 
     def get_queryset(self):
         product_id = self.request.query_params.get("product_id", None)
+        language = self.request.query_params.get("taal", None)
+
         localized_products = (
             LocalizedProduct.objects.filter(
                 product_versie__product__id=product_id,
@@ -30,6 +32,13 @@ class ProductTranslation(viewsets.ReadOnlyModelViewSet):
             .order_by("product_versie")
             .first()
         )
-        return LocalizedGeneriekProduct.objects.filter(
-            generiek_product=localized_products.product_versie.product.referentie_product.generiek_product
-        )
+        if localized_products:
+            if language:
+                return LocalizedGeneriekProduct.objects.filter(
+                    generiek_product=localized_products.product_versie.product.referentie_product.generiek_product,
+                    taal=language,
+                )
+            return LocalizedGeneriekProduct.objects.filter(
+                generiek_product=localized_products.product_versie.product.referentie_product.generiek_product,
+            )
+        return []

--- a/src/sdg/cmsapi/views.py
+++ b/src/sdg/cmsapi/views.py
@@ -2,17 +2,10 @@ from rest_framework import viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 
-from drf_spectacular.utils import extend_schema, extend_schema_view
-
-from sdg.cmsapi.serializers import (
-    LocalizedGenericProductSerializer,
-)
+from sdg.cmsapi.serializers import LocalizedGenericProductSerializer
 from sdg.producten.models.localized import LocalizedProduct, LocalizedGeneriekProduct
 
 
-@extend_schema_view(
-    retrieve=extend_schema(description="Generiek product"),
-)
 class ProductTranslation(viewsets.ReadOnlyModelViewSet):
     queryset = LocalizedProduct.objects.none()
     serializer_class = LocalizedGenericProductSerializer
@@ -40,5 +33,5 @@ class ProductTranslation(viewsets.ReadOnlyModelViewSet):
                 )
             return LocalizedGeneriekProduct.objects.filter(
                 generiek_product=localized_products.product_versie.product.referentie_product.generiek_product,
-            )
+            ).order_by("-taal")
         return []

--- a/src/sdg/conf/base.py
+++ b/src/sdg/conf/base.py
@@ -132,6 +132,7 @@ INSTALLED_APPS = [
     "zgw_consumers",
     # SDG applications
     "sdg.api",
+    "sdg.cmsapi",
     "sdg.components",
     "sdg.core",
     "sdg.utils",

--- a/src/sdg/js/components/generic.js
+++ b/src/sdg/js/components/generic.js
@@ -50,6 +50,22 @@ class GenericForm {
         })
     }
 
+    async getProductTranslationName(productId, language) {
+        const url = `${window.location.origin}/cmsapi/translation/?product_id=${productId}&taal=${language}`
+        const translationJsonResults = await fetch(url)
+            .then(response => response.json())
+            .then(data => data.results[0])
+
+        if (translationJsonResults) {
+
+            if (translationJsonResults.productTitel) {
+                return translationJsonResults.productTitel
+            }
+            return translationJsonResults.generiekProduct
+        }
+        return ""
+    }
+
     setUpDynamicProductAanwezig() {
         const input = this.node.querySelector("[name=product_aanwezig]");
         const dependency = this.getClarificationField().closest(".form__language-wrapper");
@@ -89,7 +105,7 @@ class GenericForm {
                 };
             };
 
-            displayFunc(input, dependency);
+            displayFunc(dependency);
             input.addEventListener("change", () => {
                 displayFunc(dependency);
             });
@@ -100,46 +116,44 @@ class GenericForm {
         const select = document.querySelector("#id_product_valt_onder");
         const dependency = document.querySelector('[id$="product_valt_onder_toelichting"]').closest(".form__language-wrapper");
         if (select) {
-            let previousSelectedProduct = select.options[select.selectedIndex].text;
-
-
-            const displayFunc = (select, displayDependency) => {
+            let previousSelectedProduct = null;
+            const displayFunc = async (select, displayDependency) => {
                 if (select.selectedIndex > 0) {
                     this.displayBlock(displayDependency)
                     const controls = displayDependency.querySelectorAll(".form__control");
-                    controls.forEach(element => {
+                    for (const element of controls) {
+                        previousSelectedProduct = select.value;
                         const textarea = element.querySelector("textarea");
-                        if (!textarea.value) {
-                            const defaultExplanation = document.querySelector(`.form__reference-${element.lang}`).dataset.defaultToelichting;
-                            const explanation = defaultExplanation.replace(/\[product\]/g, select.options[select.selectedIndex].text);
-                            textarea.value = explanation;
-                        }
-                    });
+                        const defaultExplanation = document.querySelector(`.form__reference-${element.lang}`).dataset.defaultToelichting;
+                        const explanation = defaultExplanation.replace(/\[product\]/g, await this.getProductTranslationName(select.value, element.lang));
+                        textarea.value = explanation;
+                    };
                 } else {
                     const controls = displayDependency.querySelectorAll(".form__control")
                     let emptyOrDefault = 0
-                    controls.forEach((element, index, array) => {
+                    let index = 0
+                    for (const element of controls) {
                         const textarea = element.querySelector("textarea");
                         const defaultExplanation = document.querySelector(`.form__reference-${element.lang}`).dataset.defaultToelichting;
-                        const explanation = defaultExplanation.replace(/\[product\]/g, previousSelectedProduct);
+                        if (previousSelectedProduct != null) {
+                            const explanation = defaultExplanation.replace(/\[product\]/g, await this.getProductTranslationName(previousSelectedProduct, element.lang));
 
-                        if (!textarea.value || textarea.value === explanation) {
-                            emptyOrDefault += 1
+                            if (!textarea.value || textarea.value === explanation) {
+                                emptyOrDefault += 1
+                            }
+
+                            if (emptyOrDefault == 2) {
+                                this.displayHidden(dependency)
+                                this.emptyFieldValues([controls[index - 1], element])
+                                previousSelectedProduct = null
+                                return
+                            }
+
+                            this.displayBlock(dependency)
                         }
-
-                        if (emptyOrDefault == 2) {
-                            this.displayHidden(dependency)
-                            this.emptyFieldValues([array[index - 1], element])
-                            return
-                        }
-
-                        this.displayBlock(dependency)
-                    })
+                        index++
+                    }
                 };
-
-                if (select.options[select.selectedIndex].text !== previousSelectedProduct) {
-                    previousSelectedProduct = select.options[select.selectedIndex].text
-                }
             };
 
             displayFunc(select, dependency);

--- a/src/sdg/producten/tests/test_views.py
+++ b/src/sdg/producten/tests/test_views.py
@@ -13,7 +13,10 @@ from sdg.producten.tests.constants import (
     NOW_DATE,
     PRODUCT_EDIT_URL,
 )
-from sdg.producten.tests.factories.localized import LocalizedProductFactory
+from sdg.producten.tests.factories.localized import (
+    LocalizedGeneriekProductFactory,
+    LocalizedProductFactory,
+)
 from sdg.producten.tests.factories.product import (
     ProductVersieFactory,
     ReferentieProductVersieFactory,
@@ -42,7 +45,10 @@ class SpecifiekProductUpdateViewTests(WebTest):
         )
 
         LocalizedProductFactory.create_batch(2, product_versie=self.product_version)
-
+        LocalizedGeneriekProductFactory.create_batch(
+            2,
+            generiek_product=self.product_version.product.referentie_product.generiek_product,
+        )
         LocalizedProductFactory.create_batch(2, product_versie=self.test)
         LocalizedProductFactory.create_batch(
             2, product_versie=self.reference_product_version

--- a/src/sdg/producten/views/product.py
+++ b/src/sdg/producten/views/product.py
@@ -187,14 +187,17 @@ class ProductUpdateView(OverheidMixin, UpdateView):
         return new_version, created
 
     def _generate_version_formset(self, version: ProductVersie):
+        product_nl = self.product.generiek_product.vertalingen.get(taal="nl")
+        product_en = self.product.generiek_product.vertalingen.get(taal="en")
+
         default_explanation_mapping = {
-            "nl": f"In de gemeente {self.lokale_overheid} valt het product {self.product} onder het product [product].",
-            "en": f"In the municipality of {self.lokale_overheid}, the product {self.product} falls under the product [product].",
+            "nl": f"In de gemeente {self.lokale_overheid} valt het product {product_nl} onder het product [product].",
+            "en": f"In the municipality of {self.lokale_overheid}, the product {product_en} falls under the product [product].",
         }
 
         default_aanwezig_toelichting_explanation_mapping = {
-            "nl": f"De gemeente {self.lokale_overheid} levert het product {self.product} niet omdat...",
-            "en": f"The municipality of {self.lokale_overheid} doesn't offer {self.product} because...",
+            "nl": f"De gemeente {self.lokale_overheid} levert het product {product_nl} niet omdat...",
+            "en": f"The municipality of {self.lokale_overheid} doesn't offer {product_en} because...",
         }
         formset = inlineformset_factory(
             ProductVersie, LocalizedProduct, form=LocalizedProductForm, extra=0

--- a/src/sdg/urls.py
+++ b/src/sdg/urls.py
@@ -49,6 +49,7 @@ urlpatterns = [
         name="invitation_accept",
     ),
     path("api/", include("sdg.api.urls", namespace="api")),
+    path("cmsapi/", include("sdg.cmsapi.urls", namespace="cmsapi")),
     path("accounts/", include("allauth.urls")),
     path("accounts/", include("sdg.accounts.urls", namespace="accounts")),
     path("organizations/", include("sdg.organisaties.urls", namespace="organisaties")),


### PR DESCRIPTION
Fixes #605

_______

**Changes**

Added api that returns the generieke localized title, product name and taal.
Updated the generic javascript to get the different language product names.
added tests for the newly added api
