### PR TITLE
:sparkles: [#692] added markdown validation

### DIFF
--- a/src/sdg/producten/models/fields.py
+++ b/src/sdg/producten/models/fields.py
@@ -1,9 +1,9 @@
 from markdownx.models import MarkdownxField as _MarkdownxField
 
-from sdg.producten.models.validators import validate_no_html
+from sdg.producten.models.validators import validate_markdown, validate_no_html
 
 
 class MarkdownxField(_MarkdownxField):
     """Override `MarkdownxField` with custom validators."""
 
-    validators = [validate_no_html]
+    validators = [validate_markdown, validate_no_html]

--- a/src/sdg/producten/tests/test_models.py
+++ b/src/sdg/producten/tests/test_models.py
@@ -90,3 +90,59 @@ class LabeledURLTests(TestCase):
                 ["label1", "https://example.com", "extra1"],
             ]
             self.localized_product.full_clean()
+
+    def test_unable_to_save_markdown_with_invaled_h_elements(self):
+        with self.assertRaises(ValidationError):
+            self.localized_product.specifieke_tekst = "# example text."
+
+            self.localized_product.full_clean()
+
+        with self.assertRaises(ValidationError):
+            self.localized_product.specifieke_tekst = "## example text."
+
+            self.localized_product.full_clean()
+
+        with self.assertRaises(ValidationError):
+            self.localized_product.specifieke_tekst = "##### example text."
+
+            self.localized_product.full_clean()
+
+        with self.assertRaises(ValidationError):
+            self.localized_product.specifieke_tekst = "###### example text."
+
+            self.localized_product.full_clean()
+
+    def test_unable_to_save_markdown_with_img_element(self):
+        with self.assertRaises(ValidationError):
+            self.localized_product.specifieke_tekst = (
+                "![alt](/path/to/image.jpg 'title') example text."
+            )
+
+            self.localized_product.full_clean()
+
+    def test_unable_to_save_markdown_with_hr_element(self):
+        with self.assertRaises(ValidationError):
+            self.localized_product.specifieke_tekst = "___"
+
+            self.localized_product.full_clean()
+
+        with self.assertRaises(ValidationError):
+            self.localized_product.specifieke_tekst = "---"
+
+            self.localized_product.full_clean()
+
+        with self.assertRaises(ValidationError):
+            self.localized_product.specifieke_tekst = "***"
+
+            self.localized_product.full_clean()
+
+    def test_unable_to_save_markdown_with_code_element(self):
+        with self.assertRaises(ValidationError):
+            self.localized_product.specifieke_tekst = "`example text` example text."
+
+            self.localized_product.full_clean()
+
+    def test_able_to_save_markdown(self):
+        self.localized_product.specifieke_tekst = "### example text\n * example text\n * example text\n * example text\n 1. example text\n 2. example text\n 3. example text\n *italic* **bold**."
+
+        self.localized_product.full_clean()


### PR DESCRIPTION
Fixes #692
_______

**Changes**

Added markdown validation so that the user can't submit a form with the following elements:
- h1
- h2
- h5
- h6
- hr
- img
- code

Added unit tests to check if the markdown fields really don't allow these tags
Added unit tests to check if accepted markdown elements get though
