### PR TITLE
:art: [#650] removed empty label option for bevoegde organisatie

### DIFF
--- a/src/sdg/producten/forms.py
+++ b/src/sdg/producten/forms.py
@@ -86,6 +86,7 @@ class ProductForm(FieldConfigurationMixin, forms.ModelForm):
     bevoegde_organisatie = forms.ModelChoiceField(
         queryset=BevoegdeOrganisatie.objects.all(),
         required=False,
+        empty_label=None,
     )
     locaties = forms.ModelMultipleChoiceField(
         queryset=None,


### PR DESCRIPTION
Fixes #650

_______

**Changes**

Removed empty label option for the bevoegde organisatie in the product.forms.ProductForm
