### PR TITLE
:bug: [#857] fixed bug where the api would crash on empty string as catalogus

### DIFF
--- a/src/sdg/api/serializers/producten.py
+++ b/src/sdg/api/serializers/producten.py
@@ -607,6 +607,13 @@ class ProductSerializer(ProductBaseSerializer):
                 bevoegde_organisatie, verantwoordelijke_organisatie
             )
 
+        if not catalogus:
+            raise serializers.ValidationError(
+                {
+                    "catalogus": "Dit is geen geldige URL. U dient een URL op te geven naar de gewenste catalogus of null te gebruiken om automatisch de juiste catalogus te selecteren."
+                }
+            )
+
         if isinstance(catalogus, dict):
             validated_data["catalogus"] = self.get_default_catalogus(
                 verantwoordelijke_organisatie

--- a/src/sdg/api/tests/test_producten.py
+++ b/src/sdg/api/tests/test_producten.py
@@ -789,10 +789,24 @@ class ProductenTests(APITestCase):
     def test_update_product_without_upn(self):
         list_url = reverse("api:product-list")
 
-        body = self.get_product_post_body({"publicatieDatum": str(NOW_DATE)})
-
         body = self.body
         body.pop("upnUri")
+
+        headers = {"HTTP_AUTHORIZATION": f"Token {self.test_token_authorization.token}"}
+
+        create_response = self.client.post(
+            list_url,
+            data=json.dumps(body),
+            content_type="application/json",
+            **headers,
+        )
+
+        self.assertEqual(create_response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_empty_string_for_catalogus(self):
+        list_url = reverse("api:product-list")
+
+        body = self.get_product_post_body({"catalogus": ""})
 
         headers = {"HTTP_AUTHORIZATION": f"Token {self.test_token_authorization.token}"}
 


### PR DESCRIPTION
Fixes #857
_______

**Changes**

- Fixed bug where api would crash on empty string as catalogus
- Added unit test to test if empty string will give you 400 page
