### PR TITLE
:bug: [#875] fixed bug where validating key could result in 500

### DIFF
--- a/src/sdg/api/views/producten.py
+++ b/src/sdg/api/views/producten.py
@@ -1,3 +1,5 @@
+from django.core.exceptions import MultipleObjectsReturned
+
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import mixins
@@ -184,13 +186,15 @@ class ProductViewSet(
             if not organisatie:
                 return None
 
-            for field in ["owms_pref_label", "owms_identifier"]:
+            for field in ["owms_identifier", "owms_pref_label"]:
                 if field in organisatie:
                     try:
                         return Overheidsorganisatie.objects.get(
                             **{field: organisatie.get(field)}
                         )
                     except Overheidsorganisatie.DoesNotExist:
+                        return None
+                    except MultipleObjectsReturned:
                         return None
 
         return None


### PR DESCRIPTION
Fixes #875
_______

**Changes**

- Changed ordering of organization in get_organisatie function from the ProductViewSet.
- Added extra validation if get request returns more then 2 answers to avoid http 500 requests.
