### PR TITLE
Feature/clean generic products

### DIFF
--- a/src/sdg/core/management/utils.py
+++ b/src/sdg/core/management/utils.py
@@ -151,19 +151,6 @@ def load_upn(data: List[Dict[str, Any]]) -> int:
         )
         upn_updated_list.append(upn.pk)
 
-        groups = [doelgroep for i in sdg_list if (doelgroep := _get_group(i))]
-        # Create generic product (and localize) for each target group
-        for group in groups:
-            generic, g_created = GeneriekProduct.objects.get_or_create(
-                upn=upn,
-                doelgroep=group,
-            )
-            if g_created:
-                LocalizedGeneriekProduct.objects.localize(
-                    instance=generic,
-                    languages=TaalChoices.get_available_languages(),
-                )
-
         if created:
             count += 1
 
@@ -172,15 +159,3 @@ def load_upn(data: List[Dict[str, Any]]) -> int:
     )
 
     return count
-
-
-def _get_group(sdg_code: str) -> str:
-    """Get the target group from a given SDG code.
-    - The range A-I equals "burger".
-    - The range J+ equals "bedrijf".
-    """
-    letter = sdg_code[0]
-    if letter in string.ascii_uppercase[:9]:
-        return "eu-burger"
-    elif letter in string.ascii_uppercase[9:]:
-        return "eu-bedrijf"

--- a/src/sdg/producten/tests/commands/test_update_generic_product_status.py
+++ b/src/sdg/producten/tests/commands/test_update_generic_product_status.py
@@ -13,6 +13,7 @@ class UpdateGenericProductStatusTests(TestCase):
         generic = GeneriekProductFactory.create(
             upn__is_verwijderd=True,
             eind_datum=None,
+            product_status=GenericProductStatus.NEW,
         )
         self.assertEqual(generic.product_status, GenericProductStatus.NEW)
 
@@ -22,9 +23,15 @@ class UpdateGenericProductStatusTests(TestCase):
         self.assertEqual(generic.product_status, GenericProductStatus.EXPIRED)
 
     def test_update_generic_product_status_eol_deleted(self):
-        generic_1 = GeneriekProductFactory.create(eind_datum=now() - timedelta(days=1))
+        generic_1 = GeneriekProductFactory.create(
+            eind_datum=now() - timedelta(days=1),
+            product_status=GenericProductStatus.NEW,
+        )
 
-        generic_2 = GeneriekProductFactory.create(eind_datum=now() + timedelta(days=1))
+        generic_2 = GeneriekProductFactory.create(
+            eind_datum=now() + timedelta(days=1),
+            product_status=GenericProductStatus.NEW,
+        )
 
         self.assertEqual(generic_1.product_status, GenericProductStatus.NEW)
         self.assertEqual(generic_2.product_status, GenericProductStatus.NEW)
@@ -37,7 +44,9 @@ class UpdateGenericProductStatusTests(TestCase):
         self.assertEqual(generic_2.product_status, GenericProductStatus.EOL)
 
     def test_update_generic_product_status_missing(self):
-        generic = GeneriekProductFactory.create(localized=True)
+        generic = GeneriekProductFactory.create(
+            localized=True, product_status=GenericProductStatus.NEW
+        )
         self.assertEqual(generic.product_status, GenericProductStatus.NEW)
 
         call_command("update_generic_product_status")

--- a/src/sdg/producten/tests/factories/product.py
+++ b/src/sdg/producten/tests/factories/product.py
@@ -33,7 +33,11 @@ class GeneriekProductFactory(DjangoModelFactory):
 
 class ProductFactory(DjangoModelFactory):
     product_aanwezig = True
-    locaties = factory.RelatedFactoryList(LocatieFactory, size=3)
+    locaties = factory.RelatedFactoryList(
+        LocatieFactory,
+        size=3,
+        lokale_overheid=factory.SelfAttribute("..catalogus.lokale_overheid"),
+    )
 
     class Meta:
         model = Product

--- a/src/sdg/producten/tests/test_product.py
+++ b/src/sdg/producten/tests/test_product.py
@@ -13,10 +13,7 @@ from sdg.conf.utils import org_type_cfg
 from sdg.core.constants import GenericProductStatus, TaalChoices
 from sdg.core.tests.factories.logius import OverheidsorganisatieFactory
 from sdg.core.tests.utils import hard_refresh_from_db
-from sdg.organisaties.tests.factories.overheid import (
-    BevoegdeOrganisatieFactory,
-    LocatieFactory,
-)
+from sdg.organisaties.tests.factories.overheid import BevoegdeOrganisatieFactory
 from sdg.producten.models import Product
 from sdg.producten.tests.constants import (
     DUMMY_TITLE,
@@ -829,9 +826,6 @@ class ProductUpdateViewTests(WebTest):
     @freeze_time(NOW_DATE)
     def test_can_update_product_information(self):
         self._change_product_status(Product.status.CONCEPT)
-        LocatieFactory.create_batch(
-            3, lokale_overheid=self.product.catalogus.lokale_overheid
-        )
 
         locations = list(self.product.get_municipality_locations())
         self.assertEqual(len(locations), 3)
@@ -957,9 +951,6 @@ class ProductUpdateViewTests(WebTest):
         self.role.is_raadpleger = True
         self.role.save()
         self._change_product_status(Product.status.CONCEPT)
-        LocatieFactory.create_batch(
-            3, lokale_overheid=self.product.catalogus.lokale_overheid
-        )
 
         locations = list(self.product.get_municipality_locations())
         self.assertEqual(len(locations), 3)
@@ -990,9 +981,6 @@ class ProductUpdateViewTests(WebTest):
         self.role.is_raadpleger = True
         self.role.save()
         self._change_product_status(Product.status.CONCEPT)
-        LocatieFactory.create_batch(
-            3, lokale_overheid=self.product.catalogus.lokale_overheid
-        )
 
         locations = list(self.product.get_municipality_locations())
         self.assertEqual(len(locations), 3)

--- a/src/sdg/utils/checks.py
+++ b/src/sdg/utils/checks.py
@@ -71,7 +71,7 @@ def check_missing_init_files(app_configs, **kwargs):
 
         errors.append(
             Warning(
-                "Directory %s does not contain an `__init__.py` file",
+                "Directory '%s' does not contain an `__init__.py` file" % dirpath,
                 hint="Consider adding this module to make sure tests are picked up",
                 id="utils.W001",
             )


### PR DESCRIPTION
Fixes #871

Replaces #889 
_______

Don't actually delete (since that doesn't work in real life scenario's due to relations) but mark as ended.
Moved all logic for generic product creation to autofill (instead of partially done in load_upn)