### PR TITLE
Clean up obsolete generic product texts

### DIFF
--- a/src/sdg/services/management/commands/import_data_from_services.py
+++ b/src/sdg/services/management/commands/import_data_from_services.py
@@ -14,61 +14,82 @@ class Command(BaseCommand):
     help = "Retrieve all configured APIs and fill generic products."
 
     def handle(self, **options):
-        updated_objects = 0
-
         for service_config in ServiceConfiguration.objects.all():
             products = service_config.retrieve_products()
 
-            for product in products:
-                localized_generic_products = LocalizedGeneriekProduct.objects.filter(
-                    generiek_product__doelgroep=service_config.doelgroep,
-                    generiek_product__upn__upn_uri=product["upnUri"],
-                    taal=product["taal"],
-                )
-                self.stdout.write(
-                    f"Updating translations for generic product '{product['upnUri']}' via {service_config}."
-                )
+            # Empty non-existing generic texts. These texts could have been
+            # present at first but removed at a later point in time. We need to
+            # reflect that change here.
+            retrieved_upn_uris = [p["upnUri"] for p in products]
+            LocalizedGeneriekProduct.objects.filter(
+                generiek_product__doelgroep=service_config.doelgroep,
+            ).exclude(generiek_product__upn__upn_uri__in=retrieved_upn_uris,).update(
+                # Don't clean everything to prevent manually entered texts from
+                # being wiped.
+                #
+                # product_titel="",
+                # generieke_tekst="",
+                # verwijzing_links=[],
+                # landelijke_link="",
+                # datum_check=None,
+                # laatst_gewijzigd=None,
+                uuid=None,
+            )
 
-                updated_objects += localized_generic_products.update(
-                    product_titel=product["titel"],
-                    generieke_tekst=product["tekst"],
-                    verwijzing_links=[
-                        [
-                            item["label"],
-                            item["url"],
-                            item["categorie"],
-                        ]
-                        for item in product["links"]
-                    ],
-                    landelijke_link=product["url"],
-                    datum_check=datetime.fromisoformat(product["laatstGecheckt"]),
-                    laatst_gewijzigd=datetime.fromisoformat(product["laatstGewijzigd"]),
-                    uuid=product["id"],
+            for product in products:
+                try:
+                    localized_generic_product = LocalizedGeneriekProduct.objects.get(
+                        generiek_product__doelgroep=service_config.doelgroep,
+                        generiek_product__upn__upn_uri=product["upnUri"],
+                        taal=product["taal"],
+                    )
+                    self.stdout.write(
+                        f"Updating translations for generic product '{product['upnUri']}' via {service_config}."
+                    )
+                except LocalizedGeneriekProduct.DoesNotExist:
+                    logger.debug(
+                        f"Generic product with UPN URI '{product['upnUri']}' does not exist."
+                    )
+                    continue
+
+                localized_generic_product.product_titel = product["titel"]
+                localized_generic_product.generieke_tekst = product["tekst"]
+                localized_generic_product.verwijzing_links = [
+                    [
+                        item["label"],
+                        item["url"],
+                        item["categorie"],
+                    ]
+                    for item in product["links"]
+                ]
+                localized_generic_product.landelijke_link = product["url"]
+                localized_generic_product.datum_check = datetime.fromisoformat(
+                    product["laatstGecheckt"]
                 )
+                localized_generic_product.laatst_gewijzigd = datetime.fromisoformat(
+                    product["laatstGewijzigd"]
+                )
+                localized_generic_product.uuid = product["id"]
+                localized_generic_product.save()
 
                 # Update organizations with their role.
-                if (
-                    first_localized_generic_product := localized_generic_products.first()
-                ):
-                    generiek_product = first_localized_generic_product.generiek_product
-                    generiek_product.verantwoordelijke_organisaties.clear()
+                generiek_product = localized_generic_product.generiek_product
+                generiek_product.verantwoordelijke_organisaties.clear()
 
-                    for org in product["organisaties"]:
-                        org_obj = Overheidsorganisatie.objects.filter(
-                            owms_identifier=org["owmsUri"]
-                        ).first()
-                        if not org_obj:
-                            logger.error(
-                                f"Could not find government organization with OWMS URI: {org['owmsUri']}"
-                            )
-                            continue
-
-                        generiek_product.verantwoordelijke_organisaties.add(
-                            org_obj, through_defaults={"rol": org["rol"]}
+                for org in product["organisaties"]:
+                    org_obj = Overheidsorganisatie.objects.filter(
+                        owms_identifier=org["owmsUri"]
+                    ).first()
+                    if not org_obj:
+                        logger.error(
+                            f"Could not find government organization with OWMS URI: {org['owmsUri']}"
                         )
+                        continue
+
+                    generiek_product.verantwoordelijke_organisaties.add(
+                        org_obj, through_defaults={"rol": org["rol"]}
+                    )
 
         self.stdout.write(
-            self.style.SUCCESS(
-                f"Successfully updated {updated_objects} localized generic products."
-            )
+            self.style.SUCCESS("Successfully updated localized generic products.")
         )

--- a/src/sdg/services/tests/test_import_data_from_services.py
+++ b/src/sdg/services/tests/test_import_data_from_services.py
@@ -57,7 +57,7 @@ class TestImportDataFromServices(CommandTestCase):
             retrieve_mock.return_value = json.load(f)["results"]
 
         out = self.call_command("import_data_from_services")
-        self.assertIn("Successfully updated 2 localized generic products.", out)
+        self.assertIn("Successfully updated localized generic products.", out)
 
         self.localized_1.refresh_from_db()
         self.assertEqual(


### PR DESCRIPTION
Sometimes, generic product texts disappear from the NP GT API's. Can have any number of reasons but we need to cleanup our end as well.

To prevent manually entered texts from disappearing, we only wipe the UUID to prevent duplicates in case a text was moved from one UPN to another (happened for "bodemsanering" which has 2 variants).