### PR TITLE
:bug: [#922] fixed bug where multiple bevoegde org would break the api

### DIFF
--- a/src/sdg/api/serializers/producten.py
+++ b/src/sdg/api/serializers/producten.py
@@ -579,7 +579,11 @@ class ProductSerializer(ProductBaseSerializer):
                     }
                 )
 
-        return None
+        raise serializers.ValidationError(
+            {
+                "verantwoordelijkeOrganisatie": "De gegeven waarde was incorect de mogelijke veld opties zijn 'naam' en 'owmsIdentifier'."
+            }
+        )
 
     def get_version_number(self, previous_date, new_date, version):
         if not previous_date:
@@ -668,8 +672,14 @@ class ProductSerializer(ProductBaseSerializer):
             )
 
         if bevoegde_organisatie:
-            bevoegde_organisatie = self.get_bevoegde_organisatie(
+            validated_data["bevoegde_organisatie"] = self.get_bevoegde_organisatie(
                 bevoegde_organisatie, verantwoordelijke_organisatie
+            )
+
+        else:
+            validated_data["bevoegde_organisatie"] = BevoegdeOrganisatie.objects.get(
+                lokale_overheid=verantwoordelijke_organisatie,
+                organisatie=verantwoordelijke_organisatie.organisatie,
             )
 
         if not catalogus:
@@ -699,13 +709,6 @@ class ProductSerializer(ProductBaseSerializer):
                     product_valt_onder["generiek_product"],
                     validated_data["catalogus"],
                 )
-
-        if bevoegde_organisatie:
-            validated_data["bevoegde_organisatie"] = bevoegde_organisatie
-        else:
-            validated_data["bevoegde_organisatie"] = BevoegdeOrganisatie.objects.get(
-                lokale_overheid=verantwoordelijke_organisatie
-            )
 
         product = Product.objects.get(
             referentie_product=validated_data["referentie_product"],

--- a/src/sdg/api/tests/test_producten.py
+++ b/src/sdg/api/tests/test_producten.py
@@ -1408,6 +1408,138 @@ class ProductenTests(APITestCase):
 
         self.assertEqual(create_response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_update_product_with_multiple_bevoegde_organisaties_available(self):
+        BevoegdeOrganisatieFactory.create(
+            lokale_overheid=self.test_lokale_overheid,
+            organisatie=self.organisatie,
+        )
+
+        list_url = reverse("api:product-list")
+
+        body = self.body
+
+        headers = {"HTTP_AUTHORIZATION": f"Token {self.test_token_authorization.token}"}
+
+        create_response = self.client.post(
+            list_url,
+            data=json.dumps(body),
+            content_type="application/json",
+            **headers,
+        )
+
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+
+        create_data = create_response.json()
+
+        self.assertEqual(
+            create_data["bevoegdeOrganisatie"]["owmsPrefLabel"], "organisatie"
+        )
+        self.assertEqual(
+            create_data["bevoegdeOrganisatie"]["owmsIdentifier"],
+            "https://www.organisatie.com",
+        )
+
+    def test_update_product_with_different_bevoegde_organisatie(self):
+        bevoede_org = BevoegdeOrganisatieFactory.create(
+            lokale_overheid=self.test_lokale_overheid,
+            organisatie=self.organisatie,
+        )
+
+        list_url = reverse("api:product-list")
+
+        body = self.get_product_post_body(
+            {
+                "bevoegdeOrganisatie": {
+                    "owmsIdentifier": bevoede_org.organisatie.owms_identifier,
+                }
+            }
+        )
+
+        headers = {"HTTP_AUTHORIZATION": f"Token {self.test_token_authorization.token}"}
+
+        create_response = self.client.post(
+            list_url,
+            data=json.dumps(body),
+            content_type="application/json",
+            **headers,
+        )
+
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+
+        create_data = create_response.json()
+
+        self.assertEqual(create_data["bevoegdeOrganisatie"]["owmsPrefLabel"], "set up")
+        self.assertEqual(
+            create_data["bevoegdeOrganisatie"]["owmsIdentifier"],
+            "https://www.setup.com",
+        )
+
+    def test_update_product_with_incorrect_bevoegde_organisatie_identifier(self):
+        list_url = reverse("api:product-list")
+
+        body = self.get_product_post_body(
+            {
+                "bevoegdeOrganisatie": {
+                    "owmsIdentifier": "incorrect indentifier",
+                }
+            }
+        )
+
+        headers = {"HTTP_AUTHORIZATION": f"Token {self.test_token_authorization.token}"}
+
+        create_response = self.client.post(
+            list_url,
+            data=json.dumps(body),
+            content_type="application/json",
+            **headers,
+        )
+
+        self.assertEqual(create_response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_product_with_incorrect_bevoegde_organisatie_naam(self):
+        list_url = reverse("api:product-list")
+
+        body = self.get_product_post_body(
+            {
+                "bevoegdeOrganisatie": {
+                    "naam": "incorrect naam",
+                }
+            }
+        )
+
+        headers = {"HTTP_AUTHORIZATION": f"Token {self.test_token_authorization.token}"}
+
+        create_response = self.client.post(
+            list_url,
+            data=json.dumps(body),
+            content_type="application/json",
+            **headers,
+        )
+
+        self.assertEqual(create_response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_product_with_incorrect_bevoegde_organisatie_field(self):
+        list_url = reverse("api:product-list")
+
+        body = self.get_product_post_body(
+            {
+                "bevoegdeOrganisatie": {
+                    "test": "???",
+                }
+            }
+        )
+
+        headers = {"HTTP_AUTHORIZATION": f"Token {self.test_token_authorization.token}"}
+
+        create_response = self.client.post(
+            list_url,
+            data=json.dumps(body),
+            content_type="application/json",
+            **headers,
+        )
+
+        self.assertEqual(create_response.status_code, status.HTTP_400_BAD_REQUEST)
+
     @freeze_time(NOW_DATE)
     def test_list_product_history(self):
         product_versie = ReferentieProductVersieFactory.create(


### PR DESCRIPTION
Fixes #922

_______

**Changes**

- changed object.get call on bevoegde org model from only lokale_overheid to lokale_overheid and name.
- added validation for wrong api field in bevoegde org 
- added tests to test for different bevoegde org, none existing bevoegde org and bevoede org with wrong field
