### PR TITLE
:art: [#929] product valt onder only contains same doelgroep

### DIFF
--- a/src/sdg/producten/forms.py
+++ b/src/sdg/producten/forms.py
@@ -169,9 +169,9 @@ class ProductForm(FieldConfigurationMixin, forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.instance.product_valt_onder:
-            selected_doelgroep = self.instance.product_valt_onder.generiek_product
+            selected_product = self.instance.product_valt_onder.generiek_product
         else:
-            selected_doelgroep = None
+            selected_product = None
 
         locations = self.instance.get_municipality_locations()
         duplicates_generiek_product_upn_labels = (
@@ -191,7 +191,7 @@ class ProductForm(FieldConfigurationMixin, forms.ModelForm):
             self.fields["product_valt_onder"]
             .queryset.filter(
                 Q(
-                    generiek_product=selected_doelgroep,
+                    generiek_product=selected_product,
                     catalogus=self.instance.catalogus,
                 )
                 | Q(

--- a/src/sdg/producten/models/product.py
+++ b/src/sdg/producten/models/product.py
@@ -365,6 +365,17 @@ class Product(ProductFieldMixin, models.Model):
             validate_specific_product,
         )
 
+        if self.product_valt_onder:
+            if (
+                self.product_valt_onder.generiek_product.doelgroep
+                != self.generiek_product.doelgroep
+            ):
+                raise ValidationError(
+                    _(
+                        f"Het product kan niet onder een product vallen met het doelgroep: '{self.product_valt_onder.generiek_product.doelgroep}'."
+                    )
+                )
+
         super().clean()
 
         if self.is_referentie_product:

--- a/src/sdg/producten/models/product.py
+++ b/src/sdg/producten/models/product.py
@@ -372,7 +372,7 @@ class Product(ProductFieldMixin, models.Model):
             ):
                 raise ValidationError(
                     _(
-                        f"Het product kan niet onder een product vallen met het doelgroep: '{self.product_valt_onder.generiek_product.doelgroep}'."
+                        "Het product kan niet onder een product vallen met een andere doelgroep."
                     )
                 )
 

--- a/src/sdg/producten/tests/factories/product.py
+++ b/src/sdg/producten/tests/factories/product.py
@@ -4,10 +4,7 @@ from factory.django import DjangoModelFactory
 from sdg.accounts.tests.factories import UserFactory
 from sdg.core.constants import GenericProductStatus
 from sdg.core.tests.factories.catalogus import ProductenCatalogusFactory
-from sdg.core.tests.factories.logius import (
-    OverheidsorganisatieFactory,
-    UniformeProductnaamFactory,
-)
+from sdg.core.tests.factories.logius import UniformeProductnaamFactory
 from sdg.organisaties.tests.factories.overheid import (
     BevoegdeOrganisatieFactory,
     LocatieFactory,


### PR DESCRIPTION
Fixes #929

_______

**Changes**

- Filtered out all products from product valt onder that are of different doelgroeps except if its already saved as one
- Added model validation to see if user doesn't tries to save product with product valt onder that has a different doelgroep
