### PR TITLE
removed codecov from pip install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements/setuptools.txt
-          pip install -r requirements/ci.txt codecov
+          pip install -r requirements/ci.txt
 
       - name: Build frontend
         run: |


### PR DESCRIPTION
Removed installing codecov on line 52 from ci.yml where we install requirements/ci.txt
