### PR TITLE
:bug: [#967] on model level clear product_aanwezig_toelichting if setting is not false

### DIFF
--- a/src/sdg/producten/models/localized.py
+++ b/src/sdg/producten/models/localized.py
@@ -316,6 +316,11 @@ class LocalizedProduct(ProductFieldMixin, TaalMixin, models.Model):
     def save(self, *args, **kwargs):
         # FIXME: Remove adding logic. Too magical.
         adding = self._state.adding
+
+        product = self.product_versie.product
+        if product.product_aanwezig is not False:
+            self.product_aanwezig_toelichting = ""
+
         super().save(*args, **kwargs)
         if adding:
             self.localize_specific_products()

--- a/src/sdg/producten/tests/commands/test_clean_products.py
+++ b/src/sdg/producten/tests/commands/test_clean_products.py
@@ -21,6 +21,7 @@ class CleanProductsTests(TestCase):
             product=localized_generic_product,
         )
         localized_product.product_aanwezig_toelichting = formatted_text
+        localized_product.product_versie.product.product_aanwezig = False
         localized_product.save()
         self.assertEqual(localized_product.product_aanwezig_toelichting, formatted_text)
 
@@ -42,6 +43,7 @@ class CleanProductsTests(TestCase):
             product=localized_generic_product,
         )
         localized_product.product_aanwezig_toelichting = formatted_text
+        localized_product.product_versie.product.product_aanwezig = False
         localized_product.save()
         self.assertEqual(localized_product.product_aanwezig_toelichting, formatted_text)
 
@@ -63,6 +65,7 @@ class CleanProductsTests(TestCase):
             product=localized_generic_product,
         )
         localized_product.product_aanwezig_toelichting = formatted_text
+        localized_product.product_versie.product.product_aanwezig = False
         localized_product.save()
         self.assertEqual(localized_product.product_aanwezig_toelichting, formatted_text)
 
@@ -84,6 +87,7 @@ class CleanProductsTests(TestCase):
             product=localized_generic_product,
         )
         localized_product.product_aanwezig_toelichting = formatted_text
+        localized_product.product_versie.product.product_aanwezig = False
         localized_product.save()
         self.assertEqual(localized_product.product_aanwezig_toelichting, formatted_text)
 


### PR DESCRIPTION
Fixes #967

_______

**Changes**

remove toelichting on model level when not false