### PR TITLE
:bug: changed sticky ckeditor panel to static

### DIFF
--- a/src/sdg/scss/components/_ckeditor.scss
+++ b/src/sdg/scss/components/_ckeditor.scss
@@ -2,6 +2,8 @@
 
 .ck {
   --ck-color-toolbar-background: $color_grey_lightest;
+
+  .ck-sticky-panel .ck-sticky-panel__content_sticky{ position: static !important; }
 }
 
 .ck-content {


### PR DESCRIPTION
Fixed bug where focusing ckeditor field made toolbar sticky would merge with global page toolbar. 