### PR TITLE
#989 fix sorted product history.

### DIFF
--- a/src/sdg/producten/models/product.py
+++ b/src/sdg/producten/models/product.py
@@ -323,7 +323,7 @@ class Product(ProductFieldMixin, models.Model):
     ):
         """:returns: The latest N versions for this product."""
         step_slice = 1 if reverse_order else 1
-        queryset = self.versies.all().order_by("-versie")
+        queryset = self.versies.all().order_by("-gewijzigd_op")
 
         if active:
             queryset = queryset.filter(publicatie_datum__lte=datetime.date.today())
@@ -334,7 +334,9 @@ class Product(ProductFieldMixin, models.Model):
 
     def get_all_versions(self, active=False, exclude_concept=False):
         """:returns: The versions for this product."""
-        queryset = self.versies.all().order_by("-versie").select_related("gemaakt_door")
+        queryset = (
+            self.versies.all().order_by("-gewijzigd_op").select_related("gemaakt_door")
+        )
 
         if active:
             queryset = queryset.filter(publicatie_datum__lte=datetime.date.today())
@@ -451,7 +453,7 @@ class ProductVersie(ProductFieldMixin, models.Model):
     class Meta:
         verbose_name = _("product versie")
         verbose_name_plural = _("product versies")
-        ordering = ("-versie",)
+        ordering = ("-gewijzigd_op",)
         unique_together = (("versie", "product"),)
 
     def __str__(self):

--- a/src/sdg/producten/tests/test_product.py
+++ b/src/sdg/producten/tests/test_product.py
@@ -1196,8 +1196,10 @@ class ProductUpdateViewTests(WebTest):
         self.assertEqual(response.status_code, 200)
 
         revisions = response.pyquery(".revision-list")
+        latest_active_version = self.product_version.gemaakt_door
+
         self.assertEqual(len(revisions), 2)
-        self.assertIn(str(self.product.gemaakt_door), revisions[0].text_content())
+        self.assertIn(str(latest_active_version), revisions[1].text_content())
         self.assertIn(str(self.reference_product), revisions[1].text_content())
 
     @freeze_time(NOW_DATE)

--- a/src/sdg/producten/tests/test_product.py
+++ b/src/sdg/producten/tests/test_product.py
@@ -1197,7 +1197,7 @@ class ProductUpdateViewTests(WebTest):
 
         revisions = response.pyquery(".revision-list")
         self.assertEqual(len(revisions), 2)
-        self.assertIn(str(self.product), revisions[0].text_content())
+        self.assertIn(str(self.product.gemaakt_door), revisions[0].text_content())
         self.assertIn(str(self.reference_product), revisions[1].text_content())
 
     @freeze_time(NOW_DATE)

--- a/src/sdg/producten/views/product.py
+++ b/src/sdg/producten/views/product.py
@@ -266,11 +266,16 @@ class ProductUpdateView(
         new_version.product = self.product
         new_version.gemaakt_door = self.request.user
         new_version.versie = self.object.versie + 1 if created else self.object.versie
+        changes_specific_fields = [
+            field
+            for field in product_form.changed_data
+            if field in settings.SDG_LOCALIZED_FORM_FIELDS
+        ]
         new_version.bewerkte_velden = list(
             chain.from_iterable(
                 [
                     localized_formset.changed_data_localized,
-                    parse_changed_data(product_form.changed_data, form=product_form),
+                    parse_changed_data(changes_specific_fields, form=product_form),
                 ]
             )
         )

--- a/src/sdg/templates/producten/_include/productversie.html
+++ b/src/sdg/templates/producten/_include/productversie.html
@@ -2,32 +2,39 @@
 
 <tr class="revision-list">
     <td class="tabs__table-cell">
-        <strong class="revision-list__item--user"><i class="fa fa-user"></i>{{ version.gemaakt_door|default:"Systeem" }}</strong>
+        <strong class="revision-list__item--user">
+            <i class="fa fa-user"></i>
+            {{ version.gemaakt_door|default:"Systeem" }}
+        </strong>
     </td>
     <td class="tabs__table-cell">
-        <li class="revision-list__item">
-            {% with last_modified=version.gewijzigd_op %}
+            <li class="revision-list__item">
                 <span class="tabs__table-cell--value">
-                    <strong>{{ last_modified }}</strong>. {{ version }} gewijzigd. &nbsp;
+                    <strong>{{ version.gewijzigd_op }} </strong>
+                    <span>—</span>
+                    <strong>{% trans "versie" %} {{version.versie}} {% if not version.publicatie_datum %}(concept){% endif %}</strong>
+                    {% if version.publicatie_datum %}
+                    <span>—</span>
+                    <span>Gepubliceerd op </span>
+                    {% blocktrans with publication_date=version.publicatie_datum %}
+                        <strong>{{ publication_date }}.</strong>
+                    {% endblocktrans %}
+                    {% endif %}
                 </span>
-            {% endwith %}
-
-            {% if version.publicatie_datum %}
-                {% blocktrans with publication_date=version.publicatie_datum %}
-                     Gepubliceerd op &nbsp <strong>{{ publication_date }}</strong>.
-                {% endblocktrans %}
-            {% endif %}
-        </li>
-        {% if version.interne_opmerkingen %}
+                
+                <span>
+                </span>
+            </li>
+            {% if version.interne_opmerkingen %}
             <li class="revision-list__remarks" title="{% trans 'Interne opmerkingen' %}">
                 <i class="fa fa-note-sticky fa-xs"></i>
                 <span>{{ version.interne_opmerkingen }}</span>
             </li>
-        {% endif %}
-        {% if version.bewerkte_velden %}
+            {% endif %}
+            {% if version.bewerkte_velden %}
             <li class="revision-list__edited-fields" title="{% trans 'Bewerkte velden' %}">
                 {% include 'producten/_include/productversie_bewerkte_velden.html' %}
             </li>
-        {% endif %}
+            {% endif %}
     </td>
 </tr>

--- a/src/sdg/templates/producten/_include/productversie.html
+++ b/src/sdg/templates/producten/_include/productversie.html
@@ -8,17 +8,24 @@
         </strong>
     </td>
     <td class="tabs__table-cell">
+
+
+        <p>
+            {{version.product}}
+            {{version.reference_product}}
+        </p>
             <li class="revision-list__item">
                 <span class="tabs__table-cell--value">
                     <strong>{{ version.gewijzigd_op }} </strong>
                     <span>—</span>
                     <strong>{% trans "versie" %} {{version.versie}} {% if not version.publicatie_datum %}(concept){% endif %}</strong>
+                    <span>{% trans "gewijzigd" %}</span>
                     {% if version.publicatie_datum %}
                     <span>—</span>
                     <span>Gepubliceerd op </span>
                     {% blocktrans with publication_date=version.publicatie_datum %}
                         <strong>{{ publication_date }}.</strong>
-                    {% endblocktrans %}
+                        {% endblocktrans %}
                     {% endif %}
                 </span>
                 


### PR DESCRIPTION
Fixes #989 

_______

- 💄 CHANGE the appearance of the `productversie.html`
- 🗃️ CHANGE the stored `new_version.bewerkte_velden` so that only the specific form field are shown inside the `productversie.html`.
- 🩹 CHANGE the `ProductVersie` order property from `versie` to `gewijzigd_op`, to make sure the order is based on the chronical timeline instead of the version.
