### PR TITLE
:bug: REMOVE wrong added encoded slash on broken links email.

### DIFF
--- a/src/sdg/producten/management/commands/send_monthly_broken_links_report.py
+++ b/src/sdg/producten/management/commands/send_monthly_broken_links_report.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
     ) -> furl:
         url_scheme = "https" if settings.IS_HTTPS else "http"
         url_netloc = Site.objects.get_current().domain.rstrip("/")
-        url_path = [segment for segment in [settings.SUBPATH] if segment]
+        url_path = [segment.lstrip("/") for segment in [settings.SUBPATH] if segment]
 
         return furl(
             scheme=url_scheme,


### PR DESCRIPTION
Fixes wrong added encoded slash.

_______

**Changes**

- [🐛 REMOVE wrong added encoded slash on broken links email.](https://github.com/maykinmedia/sdg-invoervoorziening/commit/a27193ef4051f8205182f783fa47e65c76a2b82f)