### PR TITLE
:bug: Collapse specific form onMount.

### DIFF
--- a/src/sdg/js/components/form/abstract/clarification_field_component.js
+++ b/src/sdg/js/components/form/abstract/clarification_field_component.js
@@ -88,7 +88,6 @@ export class ClarificationFieldComponent extends FormComponent {
      * @param {boolean} collapse
      */
     collapseOrExpandSpecificForm() {
-        if (this.isReferenceForm) return; // Don't collapse the specific form inside the reference product form.
         const collapse = this.availability || this.fallsUnder;
 
         const formSpecific = document.querySelector(".form__specific");

--- a/src/sdg/js/components/form/product_available.js
+++ b/src/sdg/js/components/form/product_available.js
@@ -61,12 +61,13 @@ class ProductAvailable extends ClarificationFieldComponent {
      */
     handle(options) {
         const FalseOption = this.isReferenceForm ? 1 : 2;
+        this.fallsUnder =
+            document.querySelector("#id_product_valt_onder")?.selectedIndex >
+                0 ?? false;
+
         if (this.node.selectedIndex === FalseOption) {
             this.availability = true;
-            if (
-                !this.isReferenceForm &&
-                this.node.selectedIndex != this.previousSelectedIndex
-            ) {
+            if (this.node.selectedIndex != this.previousSelectedIndex) {
                 if (confirm(PRODUCT_AANWEZIG_QUESTION)) {
                     this.resetSpecifiekeGegevens();
                 } else {

--- a/src/sdg/js/components/form/product_valt_onder.js
+++ b/src/sdg/js/components/form/product_valt_onder.js
@@ -73,6 +73,12 @@ class ProductValtOnder extends ClarificationFieldComponent {
      * @param {{ onMount: boolean }} options
      */
     handle(options) {
+        this.availability =
+            document.querySelector("#id_product_aanwezig").selectedIndex ===
+            this.isReferenceForm
+                ? 1
+                : 2;
+
         if (this.node.selectedIndex > 0) {
             this.fallsUnder = true;
 


### PR DESCRIPTION
🐛  Collapse specific form onMount if product is not available or f…alls under other product.

_______

**Changes**

- 🐛  Collapse specific form onMount if product is not available or f…alls under other product.
- 🩹 Remove logic that a reference form specific data can't be collapsed.
