### PR TITLE
:bug: FIX variable that is set in function scope instead of loop scope

### DIFF
--- a/src/sdg/producten/management/commands/check_broken_links.py
+++ b/src/sdg/producten/management/commands/check_broken_links.py
@@ -261,7 +261,6 @@ class Command(BaseCommand):
         return True
 
     def get_url_set(self, products: Product):
-        decentrale_field = (None, None)
         url_set = set()
         product_dict = defaultdict(lambda: defaultdict(list))
 
@@ -277,6 +276,7 @@ class Command(BaseCommand):
 
         for product in products:
             for localized_product in product.most_recent_version.vertalingen.all():
+                decentrale_field = (None, None)
                 for key, value in localized_product.__dict__.items():
                     if key in FIELD_NAMES_CONFIG["decentrale_label"]:
                         _, url = decentrale_field


### PR DESCRIPTION
Fixes Issue where a broken url form organization A is added to the broken links of organization B.

_______

**Changes**

- 🐛  FIX variable that is set in function scope instead of loop scope - value is used in other loops.
  - Process that is wrong implemented.
    1. Organization A has a broken link inside decentrale links field (online aanvragen).
    2. Link is handled properly for Organization A.
    3. Organization B is processed, with a contaminated tuple (`decentrale_field`).
    4. Organization B decentrale label is processed it doesn't matter if something is filled or not.
    5. With or without a label there is a check if the url inside the `decentrale_field` is valid - this is still the URL from the previous product.
    7. The url is marked as valid and for this product the url is not overwritten.
    8. The url of Organization A is processed as an url for Organization B.
