### PR TITLE
:bug: [#1044] ensured that the query is the same as productenlijst

### DIFF
--- a/src/sdg/core/constants/product.py
+++ b/src/sdg/core/constants/product.py
@@ -48,6 +48,11 @@ class GenericProductStatus(DjangoChoices):
             return exclude + [cls.NEW, cls.READY_FOR_ADMIN]
 
     @classmethod
+    def get_cms_included(cls, reference=False) -> list:
+        exclude = cls.get_cms_excluded(reference)
+        return list(cls.values.keys() - exclude)
+
+    @classmethod
     def get_api_excluded(cls):
         """
         Get excluded statuses for the API.

--- a/src/sdg/core/export.py
+++ b/src/sdg/core/export.py
@@ -193,7 +193,6 @@ class ApplicationExporter:
                 dpc="dpc_slug",
             )
         )
-
         for version in (
             ProductVersie.objects.select_related(
                 "product", "product__generiek_product", "product__bevoegde_organisatie"
@@ -201,7 +200,20 @@ class ApplicationExporter:
             .exclude(
                 product__catalogus__lokale_overheid__organisatie__owms_end_date__lte=timezone.now(),
             )
+            .exclude(
+                product__generiek_product__eind_datum__lte=datetime.date.today(),
+            )
             .filter(
+                Q(
+                    product__catalogus__is_referentie_catalogus=False,
+                    product__generiek_product__product_status__in=GenericProductStatus.get_cms_included(),
+                )
+                | Q(
+                    product__catalogus__is_referentie_catalogus=True,
+                    product__generiek_product__product_status__in=GenericProductStatus.get_cms_included(
+                        reference=True
+                    ),
+                ),
                 (
                     (
                         Q(publicatie_datum__isnull=False)
@@ -215,7 +227,6 @@ class ApplicationExporter:
                         )
                     )
                 ),
-                product__generiek_product__product_status=GenericProductStatus.READY_FOR_PUBLICATION,
             )
             .order_by("product__catalogus__pk", "product__pk", "-versie")
             .distinct("product__catalogus__pk", "product__pk")
@@ -494,9 +505,21 @@ class ApplicationExporter:
 
         published_product_count_subquery: QuerySet[ProductVersie] = (
             ProductVersie.objects.select_related("product", "product__catalogus")
+            .exclude(
+                product__generiek_product__eind_datum__lte=datetime.date.today(),
+            )
             .filter(
+                Q(
+                    product__catalogus__is_referentie_catalogus=False,
+                    product__generiek_product__product_status__in=GenericProductStatus.get_cms_included(),
+                )
+                | Q(
+                    product__catalogus__is_referentie_catalogus=True,
+                    product__generiek_product__product_status__in=GenericProductStatus.get_cms_included(
+                        reference=True
+                    ),
+                ),
                 product__catalogus__pk=OuterRef("pk"),
-                product__generiek_product__product_status=GenericProductStatus.READY_FOR_PUBLICATION,
                 publicatie_datum__lte=timezone.now(),
             )
             .order_by("product__pk", "pk", "-versie")
@@ -506,9 +529,21 @@ class ApplicationExporter:
 
         concept_product_count_subquery: QuerySet[ProductVersie] = (
             ProductVersie.objects.select_related("product")
+            .exclude(
+                product__generiek_product__eind_datum__lte=datetime.date.today(),
+            )
             .filter(
+                Q(
+                    product__catalogus__is_referentie_catalogus=False,
+                    product__generiek_product__product_status__in=GenericProductStatus.get_cms_included(),
+                )
+                | Q(
+                    product__catalogus__is_referentie_catalogus=True,
+                    product__generiek_product__product_status__in=GenericProductStatus.get_cms_included(
+                        reference=True
+                    ),
+                ),
                 product__catalogus__pk=OuterRef("pk"),
-                product__generiek_product__product_status=GenericProductStatus.READY_FOR_PUBLICATION,
                 publicatie_datum=None,
                 versie=1,
             )
@@ -524,8 +559,16 @@ class ApplicationExporter:
                 total=Count(
                     "producten",
                     filter=Q(
-                        producten__generiek_product__product_status=GenericProductStatus.READY_FOR_PUBLICATION
+                        is_referentie_catalogus=False,
+                        producten__generiek_product__product_status__in=GenericProductStatus.get_cms_included(),
+                    )
+                    | Q(
+                        is_referentie_catalogus=True,
+                        producten__generiek_product__product_status__in=GenericProductStatus.get_cms_included(
+                            reference=True
+                        ),
                     ),
+                    producten__generiek_product__eind_datum__gt=datetime.date.today(),
                 )
             )
             .annotate(

--- a/src/sdg/core/tests/test_export.py
+++ b/src/sdg/core/tests/test_export.py
@@ -249,43 +249,26 @@ class ApplicationExportTest(TestCase):
             # user isn't staff or superuser
             self.assertEqual(row["systeemrechten"], Systeemrechten.empty.label)
 
-    def test_municipality_data(self):
+    def test_referentie_municipality_data(self):
         catalogus = ProductenCatalogusFactory.create(
-            lokale_overheid__organisatie__owms_pref_label="UUUUtrecht"
+            lokale_overheid__organisatie__owms_pref_label="UUUUtrecht",
+            is_referentie_catalogus=True,
         )
         bevoegde_organisatie = BevoegdeOrganisatieFactory.create(
             lokale_overheid=catalogus.lokale_overheid
         )
 
-        for none_publication_status in [
-            GenericProductStatus.NEW,
-            GenericProductStatus.READY_FOR_ADMIN,
-            GenericProductStatus.EXPIRED,
-            GenericProductStatus.EOL,
-            GenericProductStatus.DELETED,
-            GenericProductStatus.MISSING,
-        ]:
-            generiek_product = GeneriekProductFactory.create(
-                product_status=none_publication_status
-            )
+        for status in GenericProductStatus.values.keys():
+            generiek_product = GeneriekProductFactory.create(product_status=status)
             product = SpecifiekProductFactory.create(
                 generiek_product=generiek_product,
                 catalogus=catalogus,
                 bevoegde_organisatie=bevoegde_organisatie,
             )
             SpecifiekProductVersieFactory.create(
-                product=product,
-                publicatie_datum=timezone.now(),
+                product=product, publicatie_datum=timezone.now(), versie=1
             )
 
-        SpecifiekProductVersieFactory.create_batch(
-            5,
-            product__generiek_product__product_status=GenericProductStatus.READY_FOR_PUBLICATION,
-            product__bevoegde_organisatie=bevoegde_organisatie,
-            product__catalogus=catalogus,
-            publicatie_datum=timezone.now(),
-            versie=1,
-        )
         SpecifiekProductVersieFactory.create(
             product__generiek_product__product_status=GenericProductStatus.READY_FOR_PUBLICATION,
             product__catalogus=catalogus,
@@ -300,6 +283,19 @@ class ApplicationExportTest(TestCase):
             document_info = df.parse("Document info")
             row = document_info.iloc[0].to_dict()
 
+        # these are the statuses which should be included in the queryset.
+        # and in this case published
+        self.assertEqual(
+            GenericProductStatus.get_cms_included(reference=True).sort(),
+            [
+                GenericProductStatus.READY_FOR_PUBLICATION,
+                GenericProductStatus.READY_FOR_ADMIN,
+                GenericProductStatus.EXPIRED,
+                GenericProductStatus.NEW,
+                GenericProductStatus.EOL,
+            ].sort(),
+        )
+
         self.assertEqual(
             row,
             {
@@ -308,6 +304,61 @@ class ApplicationExportTest(TestCase):
                 "aantal gepubliceerde teksten": 5,
                 "aantal conceptteksten": 1,
                 "aantal teksten": 6,
+            },
+        )
+
+    def test_municipality_data(self):
+        catalogus = ProductenCatalogusFactory.create(
+            lokale_overheid__organisatie__owms_pref_label="UUUUtrecht"
+        )
+        bevoegde_organisatie = BevoegdeOrganisatieFactory.create(
+            lokale_overheid=catalogus.lokale_overheid
+        )
+
+        for status in GenericProductStatus.values.keys():
+            generiek_product = GeneriekProductFactory.create(product_status=status)
+            product = SpecifiekProductFactory.create(
+                generiek_product=generiek_product,
+                catalogus=catalogus,
+                bevoegde_organisatie=bevoegde_organisatie,
+            )
+            SpecifiekProductVersieFactory.create(
+                product=product, publicatie_datum=timezone.now(), versie=1
+            )
+
+        SpecifiekProductVersieFactory.create(
+            product__generiek_product__product_status=GenericProductStatus.READY_FOR_PUBLICATION,
+            product__catalogus=catalogus,
+            publicatie_datum=None,
+            product__bevoegde_organisatie=bevoegde_organisatie,
+            versie=1,
+        )
+
+        with io.BytesIO() as export_file:
+            ApplicationExporter(export_file)
+            df = pd.ExcelFile(export_file)
+            document_info = df.parse("Document info")
+            row = document_info.iloc[0].to_dict()
+
+        # these are the statuses which should be included in the queryset.
+        # and in this case published
+        self.assertEqual(
+            GenericProductStatus.get_cms_included().sort(),
+            [
+                GenericProductStatus.READY_FOR_PUBLICATION,
+                GenericProductStatus.EXPIRED,
+                GenericProductStatus.EOL,
+            ].sort(),
+        )
+
+        self.assertEqual(
+            row,
+            {
+                "Unnamed: 0": 0,
+                "gemeente": "UUUUtrecht",
+                "aantal gepubliceerde teksten": 3,
+                "aantal conceptteksten": 1,
+                "aantal teksten": 4,
             },
         )
 


### PR DESCRIPTION
Fixes #1044

Altered the queryset of the exporter, to ensure to take the correct product_status into account.